### PR TITLE
fix unit test for ci

### DIFF
--- a/pallets/loans/src/mock.rs
+++ b/pallets/loans/src/mock.rs
@@ -150,6 +150,12 @@ impl MOCK_PRICE_FEEDER {
             .unwrap()
             .insert(currency_id, Some((price, 1u64)));
     }
+
+    pub fn reset() {
+        for (_, val) in MOCK_PRICE_FEEDER.lock().unwrap().iter_mut() {
+            *val = Some((1, 1u64));
+        }
+    }
 }
 
 impl PriceFeeder for MOCK_PRICE_FEEDER {
@@ -249,6 +255,8 @@ impl ExtBuilder {
         }
         .assimilate_storage::<Runtime>(&mut t)
         .unwrap();
+
+        MOCK_PRICE_FEEDER::reset();
 
         // t.into()
         let mut ext = sp_io::TestExternalities::new(t);


### PR DESCRIPTION
The static `MOCK_PRICE_FEEDER` stores prices globally that will affect different unit test contexts. 
It must be reset at the end of the test, which changed the price.