### PR TITLE
initial collator selection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2866,7 +2866,9 @@ dependencies = [
  "orml-traits",
  "orml-utilities",
  "pallet-aura",
+ "pallet-authorship",
  "pallet-balances",
+ "pallet-collator-selection",
  "pallet-collective",
  "pallet-democracy",
  "pallet-elections-phragmen",
@@ -2878,6 +2880,7 @@ dependencies = [
  "pallet-multisig",
  "pallet-prices",
  "pallet-scheduler",
+ "pallet-session",
  "pallet-sudo",
  "pallet-timestamp",
  "pallet-transaction-payment",
@@ -5081,6 +5084,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-collator-selection"
+version = "3.0.0"
+source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.4#08b7bcfe21b2ce2a26dcdaa664bf8c016f7c93ae"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "log",
+ "pallet-authorship",
+ "pallet-session",
+ "parity-scale-codec",
+ "serde",
+ "sp-runtime",
+ "sp-staking",
+ "sp-std",
+]
+
+[[package]]
 name = "pallet-collective"
 version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.4#1d04678e20555e623c974ee1127bc8a45abcf3d6"
@@ -5934,7 +5955,9 @@ dependencies = [
  "orml-traits",
  "orml-utilities",
  "pallet-aura",
+ "pallet-authorship",
  "pallet-balances",
+ "pallet-collator-selection",
  "pallet-collective",
  "pallet-democracy",
  "pallet-elections-phragmen",
@@ -5946,6 +5969,7 @@ dependencies = [
  "pallet-multisig",
  "pallet-prices",
  "pallet-scheduler",
+ "pallet-session",
  "pallet-sudo",
  "pallet-timestamp",
  "pallet-transaction-payment",

--- a/config.json
+++ b/config.json
@@ -38,32 +38,17 @@
                 {
                     "wsPort": 9977,
                     "port": 31200,
-                    "flags": [
-                        "-lpallet_collator_selection=debug",
-                        "--alice",
-                        "--",
-                        "--execution=wasm"
-                    ]
+                    "flags": ["--alice", "--", "--execution=wasm"]
                 },
                 {
                     "wsPort": 9988,
                     "port": 31300,
-                    "flags": [
-                        "-lpallet_collator_selection=debug",
-                        "--bob",
-                        "--",
-                        "--execution=wasm"
-                    ]
+                    "flags": ["--bob", "--", "--execution=wasm"]
                 },
                 {
                     "wsPort": 9999,
                     "port": 31400,
-                    "flags": [
-                        "-lpallet_collator_selection=debug",
-                        "--charlie",
-                        "--",
-                        "--execution=wasm"
-                    ]
+                    "flags": ["--charlie", "--", "--execution=wasm"]
                 }
             ]
         }

--- a/config.json
+++ b/config.json
@@ -39,7 +39,7 @@
                     "wsPort": 9977,
                     "port": 31200,
                     "flags": [
-                        "-laura=debug",
+                        "-lpallet_collator_selection=debug",
                         "--alice",
                         "--",
                         "--execution=wasm"
@@ -48,13 +48,18 @@
                 {
                     "wsPort": 9988,
                     "port": 31300,
-                    "flags": ["-laura=debug", "--bob", "--", "--execution=wasm"]
+                    "flags": [
+                        "-lpallet_collator_selection=debug",
+                        "--bob",
+                        "--",
+                        "--execution=wasm"
+                    ]
                 },
                 {
                     "wsPort": 9999,
                     "port": 31400,
                     "flags": [
-                        "-laura=debug",
+                        "-lpallet_collator_selection=debug",
                         "--charlie",
                         "--",
                         "--execution=wasm"

--- a/node/parallel/src/chain_spec/heiko.rs
+++ b/node/parallel/src/chain_spec/heiko.rs
@@ -14,9 +14,11 @@
 
 use cumulus_primitives_core::ParaId;
 use heiko_runtime::{
-    currency::DOLLARS, AuraConfig, BalancesConfig, CouncilConfig, DemocracyConfig, ElectionsConfig,
+    currency::{DOLLARS, EXISTENTIAL_DEPOSIT},
+    opaque::SessionKeys,
+    BalancesConfig, CollatorSelectionConfig, CouncilConfig, DemocracyConfig, ElectionsConfig,
     GenesisConfig, LiquidStakingConfig, LoansConfig, OracleMembershipConfig, ParachainInfoConfig,
-    SudoConfig, SystemConfig, TechnicalCommitteeConfig, TokensConfig, WASM_BINARY,
+    SessionConfig, SudoConfig, SystemConfig, TechnicalCommitteeConfig, TokensConfig, WASM_BINARY,
 };
 use primitives::*;
 use sc_service::ChainType;
@@ -135,7 +137,7 @@ pub fn local_testnet_config(id: ParaId) -> ChainSpec {
 
 fn testnet_genesis(
     root_key: AccountId,
-    initial_authorities: Vec<(AccountId, AuraId)>,
+    invulnerables: Vec<(AccountId, AuraId)>,
     oracle_accounts: Vec<AccountId>,
     endowed_accounts: Vec<AccountId>,
     id: ParaId,
@@ -143,6 +145,7 @@ fn testnet_genesis(
     let num_endowed_accounts = endowed_accounts.len();
     const ENDOWMENT: Balance = 10_000_000 * DOLLARS;
     const STASH: Balance = ENDOWMENT / 1000;
+
     GenesisConfig {
         frame_system: SystemConfig {
             code: WASM_BINARY
@@ -161,10 +164,25 @@ fn testnet_genesis(
                     .collect()
             },
         },
-        // TODO collateral selection
-        pallet_aura: AuraConfig {
-            authorities: initial_authorities.iter().map(|x| (x.1.clone())).collect(),
+        pallet_collator_selection: CollatorSelectionConfig {
+            invulnerables: invulnerables.iter().cloned().map(|(acc, _)| acc).collect(),
+            candidacy_bond: EXISTENTIAL_DEPOSIT * 16,
+            ..Default::default()
         },
+        pallet_session: SessionConfig {
+            keys: invulnerables
+                .iter()
+                .cloned()
+                .map(|(acc, aura)| {
+                    (
+                        acc.clone(),          // account id
+                        acc.clone(),          // validator id
+                        SessionKeys { aura }, // session keys
+                    )
+                })
+                .collect(),
+        },
+        pallet_aura: Default::default(),
         cumulus_pallet_aura_ext: Default::default(),
         pallet_sudo: SudoConfig { key: root_key },
         parachain_info: ParachainInfoConfig { parachain_id: id },

--- a/node/parallel/src/chain_spec/heiko.rs
+++ b/node/parallel/src/chain_spec/heiko.rs
@@ -167,7 +167,7 @@ fn testnet_genesis(
         pallet_collator_selection: CollatorSelectionConfig {
             invulnerables: invulnerables.iter().cloned().map(|(acc, _)| acc).collect(),
             candidacy_bond: EXISTENTIAL_DEPOSIT * 16,
-            ..Default::default()
+            desired_candidates: 16,
         },
         pallet_session: SessionConfig {
             keys: invulnerables

--- a/node/parallel/src/chain_spec/parallel.rs
+++ b/node/parallel/src/chain_spec/parallel.rs
@@ -14,9 +14,11 @@
 
 use cumulus_primitives_core::ParaId;
 use parallel_runtime::{
-    currency::DOLLARS, AuraConfig, BalancesConfig, CouncilConfig, DemocracyConfig, ElectionsConfig,
+    currency::{DOLLARS, EXISTENTIAL_DEPOSIT},
+    opaque::SessionKeys,
+    BalancesConfig, CollatorSelectionConfig, CouncilConfig, DemocracyConfig, ElectionsConfig,
     GenesisConfig, LiquidStakingConfig, LoansConfig, OracleMembershipConfig, ParachainInfoConfig,
-    SudoConfig, SystemConfig, TechnicalCommitteeConfig, TokensConfig, WASM_BINARY,
+    SessionConfig, SudoConfig, SystemConfig, TechnicalCommitteeConfig, TokensConfig, WASM_BINARY,
 };
 use primitives::*;
 use sc_service::ChainType;
@@ -135,7 +137,7 @@ pub fn local_testnet_config(id: ParaId) -> ChainSpec {
 
 fn testnet_genesis(
     root_key: AccountId,
-    initial_authorities: Vec<(AccountId, AuraId)>,
+    invulnerables: Vec<(AccountId, AuraId)>,
     oracle_accounts: Vec<AccountId>,
     endowed_accounts: Vec<AccountId>,
     id: ParaId,
@@ -143,6 +145,7 @@ fn testnet_genesis(
     let num_endowed_accounts = endowed_accounts.len();
     const ENDOWMENT: Balance = 10_000_000 * DOLLARS;
     const STASH: Balance = ENDOWMENT / 1000;
+
     GenesisConfig {
         frame_system: SystemConfig {
             code: WASM_BINARY
@@ -161,10 +164,25 @@ fn testnet_genesis(
                     .collect()
             },
         },
-        // TODO collateral selection
-        pallet_aura: AuraConfig {
-            authorities: initial_authorities.iter().map(|x| (x.1.clone())).collect(),
+        pallet_collator_selection: CollatorSelectionConfig {
+            invulnerables: invulnerables.iter().cloned().map(|(acc, _)| acc).collect(),
+            candidacy_bond: EXISTENTIAL_DEPOSIT * 16,
+            ..Default::default()
         },
+        pallet_session: SessionConfig {
+            keys: invulnerables
+                .iter()
+                .cloned()
+                .map(|(acc, aura)| {
+                    (
+                        acc.clone(),          // account id
+                        acc.clone(),          // validator id
+                        SessionKeys { aura }, // session keys
+                    )
+                })
+                .collect(),
+        },
+        pallet_aura: Default::default(),
         cumulus_pallet_aura_ext: Default::default(),
         pallet_sudo: SudoConfig { key: root_key },
         parachain_info: ParachainInfoConfig { parachain_id: id },

--- a/node/parallel/src/chain_spec/parallel.rs
+++ b/node/parallel/src/chain_spec/parallel.rs
@@ -167,7 +167,7 @@ fn testnet_genesis(
         pallet_collator_selection: CollatorSelectionConfig {
             invulnerables: invulnerables.iter().cloned().map(|(acc, _)| acc).collect(),
             candidacy_bond: EXISTENTIAL_DEPOSIT * 16,
-            ..Default::default()
+            desired_candidates: 16,
         },
         pallet_session: SessionConfig {
             keys: invulnerables

--- a/runtime/heiko/Cargo.toml
+++ b/runtime/heiko/Cargo.toml
@@ -39,7 +39,9 @@ orml-utilities = { git = 'https://github.com/open-web3-stack/open-runtime-module
 # orml-xcm-support                = { git = 'https://github.com/open-web3-stack/open-runtime-module-library.git', default-features = false }
 # orml-xtokens                    = { git = 'https://github.com/open-web3-stack/open-runtime-module-library.git', default-features = false }
 pallet-aura                                = { git = 'https://github.com/paritytech/substrate.git', version = '3.0.0', branch = 'polkadot-v0.9.4', default-features = false }
+pallet-authorship                          = { git = 'https://github.com/paritytech/substrate.git', version = '3.0.0', branch = 'polkadot-v0.9.4', default-features = false }
 pallet-balances                            = { git = 'https://github.com/paritytech/substrate.git', version = '3.0.0', branch = 'polkadot-v0.9.4', default-features = false }
+pallet-collator-selection                  = { git = 'https://github.com/paritytech/cumulus.git', version = '3.0.0', branch = 'polkadot-v0.9.4', default-features = false }
 pallet-collective                          = { git = 'https://github.com/paritytech/substrate.git', version = '3.0.0', branch = 'polkadot-v0.9.4', default-features = false }
 pallet-democracy                           = { git = 'https://github.com/paritytech/substrate.git', version = '3.0.0', branch = 'polkadot-v0.9.4', default-features = false }
 pallet-elections-phragmen                  = { git = 'https://github.com/paritytech/substrate.git', version = '4.0.0', branch = 'polkadot-v0.9.4', default-features = false }
@@ -51,6 +53,7 @@ pallet-membership                          = { git = 'https://github.com/parityt
 pallet-multisig                            = { git = 'https://github.com/paritytech/substrate.git', version = '3.0.0', branch = 'polkadot-v0.9.4', default-features = false }
 pallet-prices                              = { path = '../../pallets/prices', default-features = false }
 pallet-scheduler                           = { git = 'https://github.com/paritytech/substrate.git', version = '3.0.0', branch = 'polkadot-v0.9.4', default-features = false }
+pallet-session                             = { git = 'https://github.com/paritytech/substrate.git', version = '3.0.0', branch = 'polkadot-v0.9.4', default-features = false }
 pallet-sudo                                = { git = 'https://github.com/paritytech/substrate.git', version = '3.0.0', branch = 'polkadot-v0.9.4', default-features = false }
 pallet-timestamp                           = { git = 'https://github.com/paritytech/substrate.git', version = '3.0.0', branch = 'polkadot-v0.9.4', default-features = false }
 pallet-transaction-payment                 = { git = 'https://github.com/paritytech/substrate.git', version = '3.0.0', branch = 'polkadot-v0.9.4', default-features = false }
@@ -159,4 +162,7 @@ std                = [
   'pallet-democracy/std',
   'pallet-scheduler/std',
   'polkadot-runtime-common/std',
+  'pallet-session/std',
+  'pallet-authorship/std',
+  'pallet-collator-selection/std',
 ] # 'orml-xcm-support/std',

--- a/runtime/heiko/src/constants.rs
+++ b/runtime/heiko/src/constants.rs
@@ -14,6 +14,9 @@
 
 pub mod currency {
     use primitives::Balance;
+
+    pub const EXISTENTIAL_DEPOSIT: u128 = 500;
+
     pub const MILLICENTS: Balance = 1_000_000_000;
     pub const CENTS: Balance = 1_000 * MILLICENTS; // assume this is worth about a cent.
     pub const DOLLARS: Balance = 100 * CENTS;

--- a/runtime/heiko/src/constants.rs
+++ b/runtime/heiko/src/constants.rs
@@ -14,7 +14,6 @@
 
 pub mod currency {
     use primitives::Balance;
-
     pub const EXISTENTIAL_DEPOSIT: u128 = 500;
 
     pub const MILLICENTS: Balance = 1_000_000_000;

--- a/runtime/heiko/src/impls.rs
+++ b/runtime/heiko/src/impls.rs
@@ -1,0 +1,53 @@
+// Copyright 2021 Parallel Finance Developer.
+// This file is part of Parallel Finance.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use frame_support::traits::{Currency, Imbalance, OnUnbalanced};
+
+pub type NegativeImbalance<T> = <pallet_balances::Pallet<T> as Currency<
+    <T as frame_system::Config>::AccountId,
+>>::NegativeImbalance;
+
+/// Logic for the author to get a portion of fees.
+pub struct ToStakingPot<R>(sp_std::marker::PhantomData<R>);
+impl<R> OnUnbalanced<NegativeImbalance<R>> for ToStakingPot<R>
+where
+    R: pallet_balances::Config + pallet_collator_selection::Config,
+    <R as frame_system::Config>::Event: From<pallet_balances::Event<R>>,
+{
+    fn on_nonzero_unbalanced(amount: NegativeImbalance<R>) {
+        let numeric_amount = amount.peek();
+        let staking_pot = <pallet_collator_selection::Pallet<R>>::account_id();
+        <pallet_balances::Pallet<R>>::resolve_creating(&staking_pot, amount);
+        <frame_system::Pallet<R>>::deposit_event(pallet_balances::Event::Deposit(
+            staking_pot,
+            numeric_amount,
+        ));
+    }
+}
+
+pub struct DealWithFees<R>(sp_std::marker::PhantomData<R>);
+impl<R> OnUnbalanced<NegativeImbalance<R>> for DealWithFees<R>
+where
+    R: pallet_balances::Config + pallet_collator_selection::Config,
+    <R as frame_system::Config>::Event: From<pallet_balances::Event<R>>,
+{
+    fn on_unbalanceds<B>(mut fees_then_tips: impl Iterator<Item = NegativeImbalance<R>>) {
+        if let Some(mut fees) = fees_then_tips.next() {
+            if let Some(tips) = fees_then_tips.next() {
+                tips.merge_into(&mut fees);
+            }
+            <ToStakingPot<R> as OnUnbalanced<_>>::on_unbalanced(fees);
+        }
+    }
+}

--- a/runtime/heiko/src/lib.rs
+++ b/runtime/heiko/src/lib.rs
@@ -418,7 +418,7 @@ parameter_types! {
 impl pallet_collator_selection::Config for Runtime {
     type Event = Event;
     type Currency = Balances;
-    type UpdateOrigin = EnsureRoot<AccountId>;
+    type UpdateOrigin = EnsureRootOrHalfCouncil;
     type PotId = PotId;
     type MaxCandidates = MaxCandidates;
     type MaxInvulnerables = MaxInvulnerables;

--- a/runtime/heiko/src/lib.rs
+++ b/runtime/heiko/src/lib.rs
@@ -412,7 +412,6 @@ impl pallet_session::Config for Runtime {
 parameter_types! {
     pub const PotId: PalletId = PalletId(*b"PotStake");
     pub const MaxCandidates: u32 = 1000;
-    pub const SessionLength: BlockNumber = 6 * HOURS;
     pub const MaxInvulnerables: u32 = 100;
 }
 

--- a/runtime/heiko/src/lib.rs
+++ b/runtime/heiko/src/lib.rs
@@ -66,9 +66,11 @@ use xcm_builder::{
 use xcm_executor::{Config, XcmExecutor};
 
 pub mod constants;
+pub mod impls;
 // A few exports that help ease life for downstream crates.
 // re-exports
 pub use constants::{currency, fee, time};
+pub use impls::DealWithFees;
 pub use pallet_liquid_staking;
 pub use pallet_liquidation;
 pub use pallet_loans;
@@ -374,6 +376,58 @@ impl pallet_timestamp::Config for Runtime {
     type WeightInfo = ();
 }
 
+parameter_types! {
+    pub const UncleGenerations: u32 = 0;
+}
+
+impl pallet_authorship::Config for Runtime {
+    type FindAuthor = pallet_session::FindAccountFromAuthorIndex<Self, Aura>;
+    type UncleGenerations = UncleGenerations;
+    type FilterUncle = ();
+    type EventHandler = (CollatorSelection,);
+}
+
+parameter_types! {
+    pub const DisabledValidatorsThreshold: Perbill = Perbill::from_percent(33);
+    pub const Period: u32 = 6 * HOURS;
+    pub const Offset: u32 = 0;
+}
+
+impl pallet_session::Config for Runtime {
+    type Event = Event;
+    type ValidatorId = <Self as frame_system::Config>::AccountId;
+    // we don't have stash and controller, thus we don't need the convert as well.
+    type ValidatorIdOf = pallet_collator_selection::IdentityCollator;
+    type ShouldEndSession = pallet_session::PeriodicSessions<Period, Offset>;
+    type NextSessionRotation = pallet_session::PeriodicSessions<Period, Offset>;
+    type SessionManager = CollatorSelection;
+    // Essentially just Aura, but lets be pedantic.
+    type SessionHandler =
+        <opaque::SessionKeys as sp_runtime::traits::OpaqueKeys>::KeyTypeIdProviders;
+    type Keys = opaque::SessionKeys;
+    type DisabledValidatorsThreshold = DisabledValidatorsThreshold;
+    type WeightInfo = ();
+}
+
+parameter_types! {
+    pub const PotId: PalletId = PalletId(*b"PotStake");
+    pub const MaxCandidates: u32 = 1000;
+    pub const SessionLength: BlockNumber = 6 * HOURS;
+    pub const MaxInvulnerables: u32 = 100;
+}
+
+impl pallet_collator_selection::Config for Runtime {
+    type Event = Event;
+    type Currency = Balances;
+    type UpdateOrigin = EnsureRoot<AccountId>;
+    type PotId = PotId;
+    type MaxCandidates = MaxCandidates;
+    type MaxInvulnerables = MaxInvulnerables;
+    // should be a multiple of session or things will get inconsistent
+    type KickThreshold = Period;
+    type WeightInfo = ();
+}
+
 impl pallet_aura::Config for Runtime {
     type AuthorityId = AuraId;
 }
@@ -381,7 +435,7 @@ impl pallet_aura::Config for Runtime {
 impl cumulus_pallet_aura_ext::Config for Runtime {}
 
 parameter_types! {
-    pub const ExistentialDeposit: u128 = 500;
+    pub const ExistentialDeposit: u128 = currency::EXISTENTIAL_DEPOSIT;
     pub const MaxLocks: u32 = 50;
 }
 
@@ -402,7 +456,8 @@ parameter_types! {
 }
 
 impl pallet_transaction_payment::Config for Runtime {
-    type OnChargeTransaction = pallet_transaction_payment::CurrencyAdapter<Balances, ()>;
+    type OnChargeTransaction =
+        pallet_transaction_payment::CurrencyAdapter<Balances, DealWithFees<Runtime>>;
     type TransactionByteFee = TransactionByteFee;
     type WeightToFee = WeightToFee;
     type FeeMultiplierUpdate = SlowAdjustingFeeUpdate<Self>;
@@ -452,7 +507,7 @@ impl cumulus_pallet_xcmp_queue::Config for Runtime {
 impl cumulus_pallet_dmp_queue::Config for Runtime {
     type Event = Event;
     type XcmExecutor = XcmExecutor<XcmConfig>;
-    type ExecuteOverweightOrigin = frame_system::EnsureRoot<AccountId>;
+    type ExecuteOverweightOrigin = EnsureRoot<AccountId>;
 }
 
 parameter_types! {
@@ -861,6 +916,9 @@ construct_runtime!(
         CumulusXcm: cumulus_pallet_xcm::{Pallet, Call, Event<T>, Origin},
         Currencies: orml_currencies::{Pallet, Call, Event<T>},
         Tokens: orml_tokens::{Pallet, Storage, Event<T>, Config<T>},
+        Authorship: pallet_authorship::{Pallet, Call, Storage},
+        CollatorSelection: pallet_collator_selection::{Pallet, Call, Storage, Event<T>, Config<T>},
+        Session: pallet_session::{Pallet, Call, Storage, Event, Config<T>},
         Aura: pallet_aura::{Pallet, Config<T>},
         AuraExt: cumulus_pallet_aura_ext::{Pallet, Config},
         Oracle: orml_oracle::<Instance1>::{Pallet, Storage, Call, Event<T>},

--- a/runtime/parallel/Cargo.toml
+++ b/runtime/parallel/Cargo.toml
@@ -34,13 +34,16 @@ frame-system                               = { git = 'https://github.com/parityt
 frame-system-benchmarking                  = { git = 'https://github.com/paritytech/substrate.git', version = '3.0.0', branch = 'polkadot-v0.9.4', default-features = false, optional = true }
 frame-system-rpc-runtime-api               = { git = 'https://github.com/paritytech/substrate.git', version = '3.0.0', branch = 'polkadot-v0.9.4', default-features = false }
 pallet-aura                                = { git = 'https://github.com/paritytech/substrate.git', version = '3.0.0', branch = 'polkadot-v0.9.4', default-features = false }
+pallet-authorship                          = { git = 'https://github.com/paritytech/substrate.git', version = '3.0.0', branch = 'polkadot-v0.9.4', default-features = false }
 pallet-balances                            = { git = 'https://github.com/paritytech/substrate.git', version = '3.0.0', branch = 'polkadot-v0.9.4', default-features = false }
+pallet-collator-selection                  = { git = 'https://github.com/paritytech/cumulus.git', version = '3.0.0', branch = 'polkadot-v0.9.4', default-features = false }
 pallet-collective                          = { git = 'https://github.com/paritytech/substrate.git', version = '3.0.0', branch = 'polkadot-v0.9.4', default-features = false }
 pallet-democracy                           = { git = 'https://github.com/paritytech/substrate.git', version = '3.0.0', branch = 'polkadot-v0.9.4', default-features = false }
 pallet-elections-phragmen                  = { git = 'https://github.com/paritytech/substrate.git', version = '4.0.0', branch = 'polkadot-v0.9.4', default-features = false }
 pallet-membership                          = { git = 'https://github.com/paritytech/substrate.git', version = '3.0.0', branch = 'polkadot-v0.9.4', default-features = false }
 pallet-multisig                            = { git = 'https://github.com/paritytech/substrate.git', version = '3.0.0', branch = 'polkadot-v0.9.4', default-features = false }
 pallet-scheduler                           = { git = 'https://github.com/paritytech/substrate.git', version = '3.0.0', branch = 'polkadot-v0.9.4', default-features = false }
+pallet-session                             = { git = 'https://github.com/paritytech/substrate.git', version = '3.0.0', branch = 'polkadot-v0.9.4', default-features = false }
 pallet-sudo                                = { git = 'https://github.com/paritytech/substrate.git', version = '3.0.0', branch = 'polkadot-v0.9.4', default-features = false }
 pallet-timestamp                           = { git = 'https://github.com/paritytech/substrate.git', version = '3.0.0', branch = 'polkadot-v0.9.4', default-features = false }
 pallet-transaction-payment                 = { git = 'https://github.com/paritytech/substrate.git', version = '3.0.0', branch = 'polkadot-v0.9.4', default-features = false }
@@ -162,4 +165,7 @@ std                = [
   'pallet-democracy/std',
   'pallet-scheduler/std',
   'polkadot-runtime-common/std',
+  'pallet-session/std',
+  'pallet-authorship/std',
+  'pallet-collator-selection/std',
 ] # 'orml-xcm-support/std',

--- a/runtime/parallel/src/constants.rs
+++ b/runtime/parallel/src/constants.rs
@@ -14,6 +14,9 @@
 
 pub mod currency {
     use primitives::Balance;
+
+    pub const EXISTENTIAL_DEPOSIT: u128 = 500;
+
     pub const MILLICENTS: Balance = 1_000_000_000;
     pub const CENTS: Balance = 1_000 * MILLICENTS; // assume this is worth about a cent.
     pub const DOLLARS: Balance = 100 * CENTS;

--- a/runtime/parallel/src/constants.rs
+++ b/runtime/parallel/src/constants.rs
@@ -14,7 +14,6 @@
 
 pub mod currency {
     use primitives::Balance;
-
     pub const EXISTENTIAL_DEPOSIT: u128 = 500;
 
     pub const MILLICENTS: Balance = 1_000_000_000;

--- a/runtime/parallel/src/impls.rs
+++ b/runtime/parallel/src/impls.rs
@@ -1,0 +1,53 @@
+// Copyright 2021 Parallel Finance Developer.
+// This file is part of Parallel Finance.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use frame_support::traits::{Currency, Imbalance, OnUnbalanced};
+
+pub type NegativeImbalance<T> = <pallet_balances::Pallet<T> as Currency<
+    <T as frame_system::Config>::AccountId,
+>>::NegativeImbalance;
+
+/// Logic for the author to get a portion of fees.
+pub struct ToStakingPot<R>(sp_std::marker::PhantomData<R>);
+impl<R> OnUnbalanced<NegativeImbalance<R>> for ToStakingPot<R>
+where
+    R: pallet_balances::Config + pallet_collator_selection::Config,
+    <R as frame_system::Config>::Event: From<pallet_balances::Event<R>>,
+{
+    fn on_nonzero_unbalanced(amount: NegativeImbalance<R>) {
+        let numeric_amount = amount.peek();
+        let staking_pot = <pallet_collator_selection::Pallet<R>>::account_id();
+        <pallet_balances::Pallet<R>>::resolve_creating(&staking_pot, amount);
+        <frame_system::Pallet<R>>::deposit_event(pallet_balances::Event::Deposit(
+            staking_pot,
+            numeric_amount,
+        ));
+    }
+}
+
+pub struct DealWithFees<R>(sp_std::marker::PhantomData<R>);
+impl<R> OnUnbalanced<NegativeImbalance<R>> for DealWithFees<R>
+where
+    R: pallet_balances::Config + pallet_collator_selection::Config,
+    <R as frame_system::Config>::Event: From<pallet_balances::Event<R>>,
+{
+    fn on_unbalanceds<B>(mut fees_then_tips: impl Iterator<Item = NegativeImbalance<R>>) {
+        if let Some(mut fees) = fees_then_tips.next() {
+            if let Some(tips) = fees_then_tips.next() {
+                tips.merge_into(&mut fees);
+            }
+            <ToStakingPot<R> as OnUnbalanced<_>>::on_unbalanced(fees);
+        }
+    }
+}

--- a/runtime/parallel/src/lib.rs
+++ b/runtime/parallel/src/lib.rs
@@ -418,7 +418,7 @@ parameter_types! {
 impl pallet_collator_selection::Config for Runtime {
     type Event = Event;
     type Currency = Balances;
-    type UpdateOrigin = EnsureRoot<AccountId>;
+    type UpdateOrigin = EnsureRootOrHalfCouncil;
     type PotId = PotId;
     type MaxCandidates = MaxCandidates;
     type MaxInvulnerables = MaxInvulnerables;

--- a/runtime/parallel/src/lib.rs
+++ b/runtime/parallel/src/lib.rs
@@ -412,7 +412,6 @@ impl pallet_session::Config for Runtime {
 parameter_types! {
     pub const PotId: PalletId = PalletId(*b"PotStake");
     pub const MaxCandidates: u32 = 1000;
-    pub const SessionLength: BlockNumber = 6 * HOURS;
     pub const MaxInvulnerables: u32 = 100;
 }
 

--- a/runtime/parallel/src/lib.rs
+++ b/runtime/parallel/src/lib.rs
@@ -66,9 +66,11 @@ use xcm_builder::{
 use xcm_executor::{Config, XcmExecutor};
 
 pub mod constants;
+pub mod impls;
 // A few exports that help ease life for downstream crates.
 // re-exports
 pub use constants::{currency, fee, time};
+pub use impls::DealWithFees;
 pub use pallet_liquid_staking;
 pub use pallet_liquidation;
 pub use pallet_loans;
@@ -374,6 +376,58 @@ impl pallet_timestamp::Config for Runtime {
     type WeightInfo = ();
 }
 
+parameter_types! {
+    pub const UncleGenerations: u32 = 0;
+}
+
+impl pallet_authorship::Config for Runtime {
+    type FindAuthor = pallet_session::FindAccountFromAuthorIndex<Self, Aura>;
+    type UncleGenerations = UncleGenerations;
+    type FilterUncle = ();
+    type EventHandler = (CollatorSelection,);
+}
+
+parameter_types! {
+    pub const DisabledValidatorsThreshold: Perbill = Perbill::from_percent(33);
+    pub const Period: u32 = 6 * HOURS;
+    pub const Offset: u32 = 0;
+}
+
+impl pallet_session::Config for Runtime {
+    type Event = Event;
+    type ValidatorId = <Self as frame_system::Config>::AccountId;
+    // we don't have stash and controller, thus we don't need the convert as well.
+    type ValidatorIdOf = pallet_collator_selection::IdentityCollator;
+    type ShouldEndSession = pallet_session::PeriodicSessions<Period, Offset>;
+    type NextSessionRotation = pallet_session::PeriodicSessions<Period, Offset>;
+    type SessionManager = CollatorSelection;
+    // Essentially just Aura, but lets be pedantic.
+    type SessionHandler =
+        <opaque::SessionKeys as sp_runtime::traits::OpaqueKeys>::KeyTypeIdProviders;
+    type Keys = opaque::SessionKeys;
+    type DisabledValidatorsThreshold = DisabledValidatorsThreshold;
+    type WeightInfo = ();
+}
+
+parameter_types! {
+    pub const PotId: PalletId = PalletId(*b"PotStake");
+    pub const MaxCandidates: u32 = 1000;
+    pub const SessionLength: BlockNumber = 6 * HOURS;
+    pub const MaxInvulnerables: u32 = 100;
+}
+
+impl pallet_collator_selection::Config for Runtime {
+    type Event = Event;
+    type Currency = Balances;
+    type UpdateOrigin = EnsureRoot<AccountId>;
+    type PotId = PotId;
+    type MaxCandidates = MaxCandidates;
+    type MaxInvulnerables = MaxInvulnerables;
+    // should be a multiple of session or things will get inconsistent
+    type KickThreshold = Period;
+    type WeightInfo = ();
+}
+
 impl pallet_aura::Config for Runtime {
     type AuthorityId = AuraId;
 }
@@ -381,7 +435,7 @@ impl pallet_aura::Config for Runtime {
 impl cumulus_pallet_aura_ext::Config for Runtime {}
 
 parameter_types! {
-    pub const ExistentialDeposit: u128 = 500;
+    pub const ExistentialDeposit: u128 = currency::EXISTENTIAL_DEPOSIT;
     pub const MaxLocks: u32 = 50;
 }
 
@@ -402,8 +456,8 @@ parameter_types! {
 }
 
 impl pallet_transaction_payment::Config for Runtime {
-    // TODO add missing DealWithFees
-    type OnChargeTransaction = pallet_transaction_payment::CurrencyAdapter<Balances, ()>;
+    type OnChargeTransaction =
+        pallet_transaction_payment::CurrencyAdapter<Balances, DealWithFees<Runtime>>;
     type TransactionByteFee = TransactionByteFee;
     type WeightToFee = WeightToFee;
     type FeeMultiplierUpdate = SlowAdjustingFeeUpdate<Self>;
@@ -453,7 +507,7 @@ impl cumulus_pallet_xcmp_queue::Config for Runtime {
 impl cumulus_pallet_dmp_queue::Config for Runtime {
     type Event = Event;
     type XcmExecutor = XcmExecutor<XcmConfig>;
-    type ExecuteOverweightOrigin = frame_system::EnsureRoot<AccountId>;
+    type ExecuteOverweightOrigin = EnsureRoot<AccountId>;
 }
 
 parameter_types! {
@@ -861,6 +915,9 @@ construct_runtime!(
         CumulusXcm: cumulus_pallet_xcm::{Pallet, Call, Event<T>, Origin},
         Currencies: orml_currencies::{Pallet, Call, Event<T>},
         Tokens: orml_tokens::{Pallet, Storage, Event<T>, Config<T>},
+        Authorship: pallet_authorship::{Pallet, Call, Storage},
+        CollatorSelection: pallet_collator_selection::{Pallet, Call, Storage, Event<T>, Config<T>},
+        Session: pallet_session::{Pallet, Call, Storage, Event, Config<T>},
         Aura: pallet_aura::{Pallet, Config<T>},
         AuraExt: cumulus_pallet_aura_ext::{Pallet, Config},
         Oracle: orml_oracle::<Instance1>::{Pallet, Storage, Call, Event<T>},


### PR DESCRIPTION
close: #117 

This uses the same method as statemint, acala has different method

1. anyone can register himself as candidate using `register_as_candidate`, some tokens will be reserved
2. fees will be collected by collator selection's pallet account
3. every session will kick stale candidates, stale candidates => not authoring block in N blocks
4. author of block can win 1/2 of collator selection's pallet account balance - min_balance (ED)

now collator can get native token, in the future they should be able to get PARA/HEIKO

- [x] test producing block still works
- [x] test register as collator and win fees