### PR TITLE
Add more units tests to attest edge cases involving errors - Part 1

### DIFF
--- a/pallets/loans/benchmarking/src/lib.rs
+++ b/pallets/loans/benchmarking/src/lib.rs
@@ -13,7 +13,7 @@ use orml_traits::MultiCurrency;
 use pallet_loans::{Config as LoansConfig, InterestRateModel, Pallet as Loans};
 use primitives::{CurrencyId, PriceWithDecimal, Rate, Ratio};
 use sp_runtime::traits::{Bounded, One, StaticLookup};
-use sp_runtime::{FixedPointNumber, FixedU128};
+use sp_runtime::{ArithmeticError, DispatchError, FixedPointNumber, FixedU128};
 use sp_std::prelude::*;
 use sp_std::vec;
 
@@ -135,7 +135,7 @@ benchmarks! {
         let exchange_rate = Loans::<T>::exchange_rate(DOT);
         let redeem_amount = exchange_rate
             .checked_mul_int(deposits.voucher_balance)
-            .ok_or(pallet_loans::Error::<T>::Overflow)?;
+            .ok_or(DispatchError::Arithmetic(ArithmeticError::Overflow))?;
         let initial_balance = <T as LoansConfig>::Currency::free_balance(DOT, &Loans::<T>::account_id());
     }: {
          let _ = Loans::<T>::redeem_all(SystemOrigin::Signed(caller.clone()).into(), DOT);

--- a/pallets/loans/src/lib.rs
+++ b/pallets/loans/src/lib.rs
@@ -34,9 +34,11 @@ use frame_support::{
 };
 use frame_system::pallet_prelude::*;
 use orml_traits::{MultiCurrency, MultiCurrencyExtended};
+pub use pallet::*;
 use primitives::{
     Amount, Balance, CurrencyId, Multiplier, Price, PriceFeeder, Rate, Ratio, Timestamp,
 };
+use sp_runtime::ArithmeticError;
 use sp_runtime::{
     traits::{
         AccountIdConversion, CheckedAdd, CheckedDiv, CheckedMul, CheckedSub, StaticLookup, Zero,
@@ -45,18 +47,12 @@ use sp_runtime::{
 };
 use sp_std::result;
 use sp_std::vec::Vec;
-
-pub use pallet::*;
-
-pub mod weights;
-
 pub use weights::WeightInfo;
 
-#[cfg(test)]
 mod mock;
 mod rate;
-#[cfg(test)]
 mod tests;
+pub mod weights;
 
 /// Container for borrow balance information
 #[derive(Encode, Decode, Eq, PartialEq, Copy, Clone, RuntimeDebug, Default)]

--- a/pallets/loans/src/lib.rs
+++ b/pallets/loans/src/lib.rs
@@ -127,7 +127,7 @@ pub mod pallet {
         /// Insufficient collateral asset to borrow more or disable collateral
         InsufficientCollateral,
         /// Repay amount greater than borrow balance
-        RepayAmountTooBig,
+        RepayAmountExceedsCloseFactor,
         /// Asset already enabled/disabled collateral
         DuplicateOperation,
         /// No deposit asset
@@ -952,7 +952,7 @@ impl<T: Config> Pallet<T> {
     ) -> DispatchResult {
         let account_borrows = Self::borrow_balance_stored(borrower, currency_id)?;
         if account_borrows < repay_amount {
-            return Err(Error::<T>::RepayAmountTooBig.into());
+            return Err(Error::<T>::RepayAmountExceedsCloseFactor.into());
         }
 
         T::Currency::transfer(*currency_id, borrower, &Self::account_id(), repay_amount)?;
@@ -1055,7 +1055,7 @@ impl<T: Config> Pallet<T> {
         // we can only liquidate 50% of the borrows
         let close_factor = CloseFactor::<T>::get(liquidate_currency_id);
         if close_factor.mul_floor(account_borrows) < repay_amount {
-            return Err(Error::<T>::RepayAmountTooBig.into());
+            return Err(Error::<T>::RepayAmountExceedsCloseFactor.into());
         }
 
         //calculate collateral_token_sum price

--- a/pallets/loans/src/mock.rs
+++ b/pallets/loans/src/mock.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![cfg(test)]
+
 mod loans {
     pub use super::super::*;
 }

--- a/pallets/loans/src/tests.rs
+++ b/pallets/loans/src/tests.rs
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Unit tests for the loans module.
+#![cfg(test)]
+
 
 use frame_support::{assert_noop, assert_ok};
 use primitives::SECONDS_PER_YEAR;

--- a/pallets/loans/src/tests.rs
+++ b/pallets/loans/src/tests.rs
@@ -14,6 +14,7 @@
 
 #![cfg(test)]
 
+mod liquidate_borrow;
 
 use frame_support::{assert_noop, assert_ok};
 use primitives::SECONDS_PER_YEAR;
@@ -80,14 +81,14 @@ fn mint_works() {
 }
 
 #[test]
-fn mint_failed() {
+fn mint_must_return_err_when_overflows_occur() {
     ExtBuilder::default().build().execute_with(|| {
-        // calculate collateral amount failed
+        // Amout is too large
+        assert_noop!(Loans::mint(Origin::signed(ALICE), DOT, u128::MAX), OVERFLOW,);
+
+        // Exchange rate must ge greater than zero
         ExchangeRate::<Runtime>::insert(DOT, Rate::zero());
-        assert_noop!(
-            Loans::mint(Origin::signed(ALICE), DOT, 100),
-            Error::<Runtime>::Underflow,
-        );
+        assert_noop!(Loans::mint(Origin::signed(ALICE), DOT, 100), UNDERFLOW);
     })
 }
 
@@ -114,6 +115,21 @@ fn redeem_works() {
             <Runtime as Config>::Currency::free_balance(DOT, &ALICE),
             million_dollar(920),
         );
+    })
+}
+
+#[test]
+fn redeem_must_return_err_when_overflows_occur() {
+    ExtBuilder::default().build().execute_with(|| {
+        // Amount is too large
+        assert_noop!(
+            Loans::redeem(Origin::signed(ALICE), DOT, u128::MAX),
+            OVERFLOW,
+        );
+
+        // Exchange rate must ge greater than zero
+        ExchangeRate::<Runtime>::insert(DOT, Rate::zero());
+        assert_noop!(Loans::redeem(Origin::signed(ALICE), DOT, 100), UNDERFLOW);
     })
 }
 
@@ -241,69 +257,6 @@ fn repay_borrow_all_works() {
         let borrow_snapshot = Loans::account_borrows(KSM, ALICE);
         assert_eq!(borrow_snapshot.principal, 0);
         assert_eq!(borrow_snapshot.borrow_index, Loans::borrow_index(KSM));
-    })
-}
-
-#[test]
-fn liquidate_borrow_works() {
-    ExtBuilder::default().build().execute_with(|| {
-        // Bob deposits 200 KSM
-        assert_ok!(Loans::mint(Origin::signed(BOB), KSM, million_dollar(200)));
-        // Alice deposits 200 DOT as collateral
-        assert_ok!(Loans::mint(Origin::signed(ALICE), DOT, million_dollar(200)));
-        assert_ok!(Loans::collateral_asset(Origin::signed(ALICE), DOT, true));
-        // Alice borrows 100 KSM
-        assert_ok!(Loans::borrow(
-            Origin::signed(ALICE),
-            KSM,
-            million_dollar(100)
-        ));
-        // adjust KSM price to make ALICE generate shortfall
-        MOCK_PRICE_FEEDER::set_price(KSM, 2.into());
-        // BOB repay the KSM borrow balance and get DOT from ALICE
-        assert_ok!(Loans::liquidate_borrow(
-            Origin::signed(BOB),
-            ALICE,
-            KSM,
-            million_dollar(50),
-            DOT
-        ));
-
-        // KSM price = 2
-        // incentive = repay KSM value * 1.1 = (50 * 2) * 1.1 = 110
-        // Alice DOT: cash - deposit = 1000 - 200 = 800
-        // Alice DOT collateral: deposit - incentive = 200 - 110 = 90
-        // Alice KSM: cash + borrow = 1000 + 100 = 1100
-        // Alice KSM borrow balance: origin borrow balance - repay amount = 100 - 50 = 50
-        // Bob KSM: cash - deposit - repay = 1000 - 200 - 50 = 750
-        // Bob DOT collateral: incentive = 110
-        assert_eq!(
-            <Runtime as Config>::Currency::free_balance(DOT, &ALICE),
-            million_dollar(800),
-        );
-        assert_eq!(
-            Loans::exchange_rate(DOT)
-                .saturating_mul_int(Loans::account_deposits(DOT, ALICE).voucher_balance),
-            90000000000000000000,
-        );
-        assert_eq!(
-            <Runtime as Config>::Currency::free_balance(KSM, &ALICE),
-            million_dollar(1100),
-        );
-        assert_eq!(
-            Loans::account_borrows(KSM, ALICE).principal,
-            million_dollar(50)
-        );
-        assert_eq!(
-            <Runtime as Config>::Currency::free_balance(KSM, &BOB),
-            million_dollar(750)
-        );
-        assert_eq!(
-            Loans::exchange_rate(DOT)
-                .saturating_mul_int(Loans::account_deposits(DOT, BOB).voucher_balance),
-            110000000000000000000,
-        );
-        MOCK_PRICE_FEEDER::reset();
     })
 }
 

--- a/pallets/loans/src/tests/liquidate_borrow.rs
+++ b/pallets/loans/src/tests/liquidate_borrow.rs
@@ -1,0 +1,128 @@
+use crate::{
+    mock::{Loans, Origin, Runtime, ALICE, BOB, DOT, KSM, MOCK_PRICE_FEEDER},
+    tests::{million_dollar, ExtBuilder},
+    Config, Error, LiquidationIncentive,
+};
+use frame_support::{assert_noop, assert_ok};
+use orml_traits::MultiCurrency;
+use primitives::Rate;
+use sp_runtime::{traits::Bounded, FixedPointNumber};
+
+#[test]
+fn borrower_must_have_some_borrowed_balance() {
+    ExtBuilder::default().build().execute_with(|| {
+        initial_setup();
+        assert_noop!(
+            Loans::liquidate_borrow(Origin::signed(BOB), ALICE, KSM, 0, DOT),
+            Error::<Runtime>::NoBorrowBalance
+        );
+    })
+}
+
+#[test]
+fn collateral_value_must_be_less_than_liquidation_value() {
+    ExtBuilder::default().build().execute_with(|| {
+        initial_setup();
+        alice_borrows_100_ksm();
+        MOCK_PRICE_FEEDER::set_price(KSM, Rate::from_float(2000.0));
+        LiquidationIncentive::<Runtime>::insert(KSM, Rate::from_float(200.0));
+        assert_noop!(
+            Loans::liquidate_borrow(Origin::signed(BOB), ALICE, KSM, million_dollar(50), DOT),
+            Error::<Runtime>::RepayValueGreaterThanCollateral
+        );
+    })
+}
+
+#[test]
+fn full_workflow_works_as_expected() {
+    ExtBuilder::default().build().execute_with(|| {
+        initial_setup();
+        alice_borrows_100_ksm();
+        // adjust KSM price to make ALICE generate shortfall
+        MOCK_PRICE_FEEDER::set_price(KSM, 2.into());
+        // BOB repay the KSM borrow balance and get DOT from ALICE
+        assert_ok!(Loans::liquidate_borrow(
+            Origin::signed(BOB),
+            ALICE,
+            KSM,
+            million_dollar(50),
+            DOT
+        ));
+
+        // KSM price = 2
+        // incentive = repay KSM value * 1.1 = (50 * 2) * 1.1 = 110
+        // Alice DOT: cash - deposit = 1000 - 200 = 800
+        // Alice DOT collateral: deposit - incentive = 200 - 110 = 90
+        // Alice KSM: cash + borrow = 1000 + 100 = 1100
+        // Alice KSM borrow balance: origin borrow balance - repay amount = 100 - 50 = 50
+        // Bob KSM: cash - deposit - repay = 1000 - 200 - 50 = 750
+        // Bob DOT collateral: incentive = 110
+        assert_eq!(
+            <Runtime as Config>::Currency::free_balance(DOT, &ALICE),
+            million_dollar(800),
+        );
+        assert_eq!(
+            Loans::exchange_rate(DOT)
+                .saturating_mul_int(Loans::account_deposits(DOT, ALICE).voucher_balance),
+            90000000000000000000,
+        );
+        assert_eq!(
+            <Runtime as Config>::Currency::free_balance(KSM, &ALICE),
+            million_dollar(1100),
+        );
+        assert_eq!(
+            Loans::account_borrows(KSM, ALICE).principal,
+            million_dollar(50)
+        );
+        assert_eq!(
+            <Runtime as Config>::Currency::free_balance(KSM, &BOB),
+            million_dollar(750)
+        );
+        assert_eq!(
+            Loans::exchange_rate(DOT)
+                .saturating_mul_int(Loans::account_deposits(DOT, BOB).voucher_balance),
+            110000000000000000000,
+        );
+        MOCK_PRICE_FEEDER::reset();
+    })
+}
+
+#[test]
+fn liquidator_can_not_repay_more_than_the_close_factor_pct_multiplier() {
+    ExtBuilder::default().build().execute_with(|| {
+        initial_setup();
+        alice_borrows_100_ksm();
+        MOCK_PRICE_FEEDER::set_price(KSM, 20.into());
+        assert_noop!(
+            Loans::liquidate_borrow(Origin::signed(BOB), ALICE, KSM, million_dollar(51), DOT),
+            Error::<Runtime>::RepayAmountExceedsCloseFactor
+        );
+    })
+}
+
+#[test]
+fn liquidator_must_not_be_borrower() {
+    ExtBuilder::default().build().execute_with(|| {
+        initial_setup();
+        assert_noop!(
+            Loans::liquidate_borrow(Origin::signed(ALICE), ALICE, KSM, 0, DOT),
+            Error::<Runtime>::LiquidatorIsBorrower
+        );
+    })
+}
+
+fn alice_borrows_100_ksm() {
+    assert_ok!(Loans::borrow(
+        Origin::signed(ALICE),
+        KSM,
+        million_dollar(100)
+    ));
+}
+
+fn initial_setup() {
+    // Bob deposits 200 KSM
+    assert_ok!(Loans::mint(Origin::signed(BOB), KSM, million_dollar(200)));
+    // Alice deposits 200 DOT as collateral
+    assert_ok!(Loans::mint(Origin::signed(ALICE), DOT, million_dollar(200)));
+    assert_ok!(Loans::collateral_asset(Origin::signed(ALICE), DOT, true));
+}

--- a/pallets/loans/src/tests/liquidate_borrow.rs
+++ b/pallets/loans/src/tests/liquidate_borrow.rs
@@ -6,7 +6,7 @@ use crate::{
 use frame_support::{assert_noop, assert_ok};
 use orml_traits::MultiCurrency;
 use primitives::Rate;
-use sp_runtime::{traits::Bounded, FixedPointNumber};
+use sp_runtime::FixedPointNumber;
 
 #[test]
 fn borrower_must_have_some_borrowed_balance() {
@@ -19,8 +19,7 @@ fn borrower_must_have_some_borrowed_balance() {
     })
 }
 
-#[test]
-fn collateral_value_must_be_less_than_liquidation_value() {
+pub(super) fn collateral_value_must_be_greater_than_liquidation_value() {
     ExtBuilder::default().build().execute_with(|| {
         initial_setup();
         alice_borrows_100_ksm();
@@ -30,11 +29,11 @@ fn collateral_value_must_be_less_than_liquidation_value() {
             Loans::liquidate_borrow(Origin::signed(BOB), ALICE, KSM, million_dollar(50), DOT),
             Error::<Runtime>::RepayValueGreaterThanCollateral
         );
+        MOCK_PRICE_FEEDER::reset();
     })
 }
 
-#[test]
-fn full_workflow_works_as_expected() {
+pub(super) fn full_workflow_works_as_expected() {
     ExtBuilder::default().build().execute_with(|| {
         initial_setup();
         alice_borrows_100_ksm();
@@ -87,8 +86,7 @@ fn full_workflow_works_as_expected() {
     })
 }
 
-#[test]
-fn liquidator_can_not_repay_more_than_the_close_factor_pct_multiplier() {
+pub(super) fn liquidator_can_not_repay_more_than_the_close_factor_pct_multiplier() {
     ExtBuilder::default().build().execute_with(|| {
         initial_setup();
         alice_borrows_100_ksm();
@@ -97,6 +95,7 @@ fn liquidator_can_not_repay_more_than_the_close_factor_pct_multiplier() {
             Loans::liquidate_borrow(Origin::signed(BOB), ALICE, KSM, million_dollar(51), DOT),
             Error::<Runtime>::RepayAmountExceedsCloseFactor
         );
+        MOCK_PRICE_FEEDER::reset();
     })
 }
 


### PR DESCRIPTION
Changes are becoming quite large so this PR only brings a subset of all required additional unit tests for an easier review. More tests will be added afterwards.

Code should be read commit-by-commit for a better understanding of what is going on.

```
    Add more units tests to attest edge cases involving errors
    
    Beyond the addition of more tests, also moves very large common errors into unified modules.
```

```
    Use built-in overflow errors
    
    Substrate already provides built-in errors for arithmetic errors so custom error enum variants are unnecessary
```

```
    Re-arrange modules, exports and cfg flags
    
    `cfg` flags for modules can be placed inside the module itself enhacing overall readability.
    Also groups scattered exports and modules declarations.
 ```