### PR TITLE
[`loans`] Add remaining unit test

### DIFF
--- a/pallets/loans/benchmarking/src/lib.rs
+++ b/pallets/loans/benchmarking/src/lib.rs
@@ -135,7 +135,7 @@ benchmarks! {
         let exchange_rate = Loans::<T>::exchange_rate(DOT);
         let redeem_amount = exchange_rate
             .checked_mul_int(deposits.voucher_balance)
-            .ok_or(DispatchError::Arithmetic(ArithmeticError::Overflow))?;
+            .ok_or(ArithmeticError::Overflow)?;
         let initial_balance = <T as LoansConfig>::Currency::free_balance(DOT, &Loans::<T>::account_id());
     }: {
          let _ = Loans::<T>::redeem_all(SystemOrigin::Signed(caller.clone()).into(), DOT);

--- a/pallets/loans/src/tests.rs
+++ b/pallets/loans/src/tests.rs
@@ -467,6 +467,22 @@ fn reduce_reserves_works() {
 }
 
 #[test]
+fn reduce_reserve_reduce_amount_must_be_less_than_total_reserves() {
+    ExtBuilder::default().build().execute_with(|| {
+        assert_ok!(Loans::add_reserves(
+            Origin::root(),
+            ALICE,
+            DOT,
+            million_dollar(100)
+        ));
+        assert_noop!(
+            Loans::reduce_reserves(Origin::root(), ALICE, DOT, million_dollar(200)),
+            Error::<Runtime>::InsufficientReserves
+        );
+    })
+}
+
+#[test]
 fn ratio_and_rate_works() {
     ExtBuilder::default().build().execute_with(|| {
         // Permill to FixedU128


### PR DESCRIPTION
Asserts the remaining non-tested variant of the `Error` enum.
Feel free to discuss if more tests are still necessary for `loans`.