### PR TITLE
New curve model

### DIFF
--- a/pallets/loans/src/rate_model.rs
+++ b/pallets/loans/src/rate_model.rs
@@ -175,9 +175,10 @@ impl CurveModel {
 
     /// Calculates the borrow interest rate of curve model
     pub fn get_borrow_rate(&self, utilization: Ratio) -> Option<Rate> {
+        const NINE: usize = 9;
         let utilization_rate: Rate = utilization.into();
         utilization_rate
-            .saturating_pow(9)
+            .saturating_pow(NINE)
             .checked_add(&self.base_rate)
     }
 }

--- a/pallets/loans/src/rate_model.rs
+++ b/pallets/loans/src/rate_model.rs
@@ -161,6 +161,8 @@ pub struct CurveModel {
 }
 
 impl CurveModel {
+    pub const MAX_BASE_RATE: Rate = Rate::from_inner(Rate::DIV / 100 * 10); // 10%
+
     /// Create a new curve model
     pub fn new_model(base_rate: Rate) -> CurveModel {
         Self { base_rate }
@@ -168,13 +170,15 @@ impl CurveModel {
 
     /// Check the curve model for sanity
     pub fn check_model(&self) -> bool {
-        true
+        self.base_rate <= Self::MAX_BASE_RATE
     }
 
     /// Calculates the borrow interest rate of curve model
-    pub fn get_borrow_rate(&self, _utilization: Ratio) -> Option<Rate> {
-        // TODO: Need to implement the curve model
-        None
+    pub fn get_borrow_rate(&self, utilization: Ratio) -> Option<Rate> {
+        let utilization_rate: Rate = utilization.into();
+        utilization_rate
+            .saturating_pow(9)
+            .checked_add(&self.base_rate)
     }
 }
 
@@ -264,6 +268,15 @@ mod tests {
             supply_rate,
             borrow_rate
                 .saturating_mul(((Ratio::one().saturating_sub(reserve_factor)) * util).into()),
+        );
+    }
+
+    #[test]
+    fn curve_model_correctly_calculates_borrow_rate() {
+        let model = CurveModel::new_model(Rate::from_inner(Rate::DIV / 100 * 2));
+        assert_eq!(
+            model.get_borrow_rate(Ratio::from_percent(80)).unwrap(),
+            Rate::from_inner(154217728000000000)
         );
     }
 }


### PR DESCRIPTION
## `x` and `y` axis (Domains)

By looking at https://docs.parallel.fi/white-paper#3-experimental-models, it is possible to see on the Cartesian plane that both axis are 0 to 1 real numbers that represent percentages, therefore, a equation for the new curve has `x ∈ ℝ | 0 <= x <= 1` and `y ∈ ℝ | 0 <= x <= 1` domains.

## Curve choice

It is still not clear to me yet which curve should perform best for Parallel. For now, any exponential formula with an adjustable constant should be good enough for experimentation because if the output value is too high or too low, then the constant could be easily modified.
Taking into consideration the above considerations, it is possible to use `y = (C^x - 1)/(C - 1), where C = constant`.

<sub>y = (256^x - 1)/(256 - 1)</sub>
![save](https://user-images.githubusercontent.com/17877264/123437717-5ad30b80-d5a6-11eb-93ae-ea7904e9a5cf.png)

Or `y = x^9 + C, where C = base_rate and y > 0` as suggested by @yz89.

<sub>y = x^9 + 0.02</sub>
![save(1)](https://user-images.githubusercontent.com/17877264/123437969-9cfc4d00-d5a6-11eb-866c-70595050a94e.png)

## Other considerations

* The equation of https://docs.parallel.fi/white-paper#3-1-curve-interest-rate-model does not specify what the `b` and `c` variables mean or the range of the `n` variable used for summing. Due to this situation and by request, another equation was used to evaluate `BorrowInterestRate` but future formula modifications can still occur if necessary.
* This PR only adds the new curve using `y = x^9 + C` for calculation. Future PRs can be created to actually change the internal algebraic operations of loans with this model.