### PR TITLE
fetch liquid price and add test

### DIFF
--- a/pallets/liquid-staking/src/lib.rs
+++ b/pallets/liquid-staking/src/lib.rs
@@ -30,7 +30,7 @@ use xcm::v0::{Junction, MultiLocation, NetworkId};
 use orml_traits::{MultiCurrency, MultiCurrencyExtended};
 
 pub use pallet::*;
-use primitives::{Amount, Balance, CurrencyId, Rate, XTransfer};
+use primitives::{Amount, Balance, CurrencyId, ExchangeRateProvider, Rate, XTransfer};
 
 #[cfg(test)]
 mod mock;
@@ -520,5 +520,11 @@ pub mod pallet {
 impl<T: Config> Pallet<T> {
     pub fn account_id() -> T::AccountId {
         T::PalletId::get().into_account()
+    }
+}
+
+impl<T: Config> ExchangeRateProvider for Pallet<T> {
+    fn get_exchange_rate() -> Rate {
+        ExchangeRate::<T>::get()
     }
 }

--- a/pallets/prices/src/lib.rs
+++ b/pallets/prices/src/lib.rs
@@ -25,10 +25,15 @@
 
 use frame_support::{pallet_prelude::*, transactional};
 use frame_system::pallet_prelude::*;
+use orml_oracle::DataProviderExtended;
 use orml_traits::DataProvider;
 pub use pallet::*;
 use primitives::*;
-use sp_runtime::{traits::CheckedDiv, FixedU128};
+use sp_runtime::{
+    traits::{CheckedDiv, CheckedMul},
+    FixedU128,
+};
+use sp_std::vec::Vec;
 
 #[cfg(test)]
 mod mock;
@@ -44,10 +49,23 @@ pub mod pallet {
         type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
 
         /// The data source, such as Oracle.
-        type Source: DataProvider<CurrencyId, TimeStampedPrice>;
+        type Source: DataProvider<CurrencyId, TimeStampedPrice>
+            + DataProviderExtended<CurrencyId, TimeStampedPrice>;
 
         /// The origin which may set prices feed to system.
         type FeederOrigin: EnsureOrigin<Self::Origin>;
+
+        /// Currency used for staking
+        #[pallet::constant]
+        type StakingCurrency: Get<CurrencyId>;
+
+        /// Currency used for liquid voucher
+        #[pallet::constant]
+        type LiquidCurrency: Get<CurrencyId>;
+
+        /// The provider of the exchange rate between liquid currency and
+        /// staking currency.
+        type LiquidStakingExchangeRateProvider: ExchangeRateProvider;
     }
 
     #[pallet::event]
@@ -124,14 +142,30 @@ impl<T: Config> PriceFeeder for Pallet<T> {
     fn get_price(currency_id: &CurrencyId) -> Option<PriceDetail> {
         // if emergency price exists, return it, otherwise return latest price from oracle.
         Self::get_emergency_price(currency_id).or_else(|| {
-            T::Source::get(&currency_id).and_then(|p| {
-                10u128.checked_pow(p.value.decimal.into()).and_then(|d| {
-                    p.value
-                        .price
-                        .checked_div(&FixedU128::from_inner(d))
-                        .map(|price| (price, p.timestamp))
+            if currency_id == &T::LiquidCurrency::get() {
+                T::Source::get(&T::StakingCurrency::get()).and_then(|p| {
+                    10u128.checked_pow(p.value.decimal.into()).and_then(|d| {
+                        p.value
+                            .price
+                            .checked_div(&FixedU128::from_inner(d))
+                            .and_then(|staking_currency_price| {
+                                staking_currency_price.checked_mul(
+                                    &T::LiquidStakingExchangeRateProvider::get_exchange_rate(),
+                                )
+                            })
+                            .map(|price| (price, p.timestamp))
+                    })
                 })
-            })
+            } else {
+                T::Source::get(&currency_id).and_then(|p| {
+                    10u128.checked_pow(p.value.decimal.into()).and_then(|d| {
+                        p.value
+                            .price
+                            .checked_div(&FixedU128::from_inner(d))
+                            .map(|price| (price, p.timestamp))
+                    })
+                })
+            }
         })
     }
 }
@@ -148,5 +182,31 @@ impl<T: Config> EmergencyPriceFeeder<CurrencyId, PriceWithDecimal> for Pallet<T>
     fn reset_emergency_price(currency_id: CurrencyId) {
         EmergencyPrice::<T>::remove(currency_id);
         <Pallet<T>>::deposit_event(Event::ResetPrice(currency_id));
+    }
+}
+
+impl<T: Config> DataProviderExtended<CurrencyId, TimeStampedPrice> for Pallet<T> {
+    fn get_no_op(key: &CurrencyId) -> Option<TimeStampedPrice> {
+        if key == &T::LiquidCurrency::get() {
+            T::Source::get_no_op(&T::StakingCurrency::get()).and_then(|p| {
+                p.value
+                    .price
+                    .checked_mul(&T::LiquidStakingExchangeRateProvider::get_exchange_rate())
+                    .map(|price| TimeStampedPrice {
+                        value: PriceWithDecimal {
+                            price,
+                            decimal: p.value.decimal,
+                        },
+                        timestamp: p.timestamp,
+                    })
+            })
+        } else {
+            T::Source::get_no_op(key)
+        }
+    }
+
+    #[allow(clippy::complexity)]
+    fn get_all_values() -> Vec<(CurrencyId, Option<TimeStampedPrice>)> {
+        T::Source::get_all_values()
     }
 }

--- a/pallets/prices/src/mock.rs
+++ b/pallets/prices/src/mock.rs
@@ -72,19 +72,48 @@ impl DataProvider<CurrencyId, TimeStampedPrice> for MockDataProvider {
                 },
                 timestamp: 0,
             }),
+            KSM => Some(TimeStampedPrice {
+                value: PriceWithDecimal {
+                    price: Price::saturating_from_integer(500),
+                    decimal: 12,
+                },
+                timestamp: 0,
+            }),
             _ => None,
         }
     }
 }
 
+impl DataProviderExtended<CurrencyId, TimeStampedPrice> for MockDataProvider {
+    fn get_no_op(_key: &CurrencyId) -> Option<TimeStampedPrice> {
+        None
+    }
+
+    fn get_all_values() -> Vec<(CurrencyId, Option<TimeStampedPrice>)> {
+        vec![]
+    }
+}
+
+pub struct LiquidStakingExchangeRateProvider;
+impl ExchangeRateProvider for LiquidStakingExchangeRateProvider {
+    fn get_exchange_rate() -> Rate {
+        Rate::saturating_from_rational(150, 100)
+    }
+}
+
 ord_parameter_types! {
     pub const One: AccountId = 1;
+    pub const StakingCurrency: CurrencyId = CurrencyId::KSM;
+    pub const LiquidCurrency: CurrencyId = CurrencyId::xKSM;
 }
 
 impl Config for Runtime {
     type Event = Event;
     type Source = MockDataProvider;
     type FeederOrigin = EnsureSignedBy<One, AccountId>;
+    type StakingCurrency = StakingCurrency;
+    type LiquidCurrency = LiquidCurrency;
+    type LiquidStakingExchangeRateProvider = LiquidStakingExchangeRateProvider;
 }
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Runtime>;

--- a/pallets/prices/src/tests.rs
+++ b/pallets/prices/src/tests.rs
@@ -31,7 +31,7 @@ fn get_price_from_oracle() {
         );
 
         // currency not exist
-        assert_eq!(Prices::get_price(&KSM), None);
+        assert_eq!(Prices::get_price(&CurrencyId::xDOT), None);
     });
 }
 
@@ -184,5 +184,22 @@ fn reset_price_call_work() {
             .iter()
             .any(|record| record.event == reset_price_event));
         assert_eq!(Prices::reset_price(Origin::signed(1), DOT), Ok(().into()));
+    });
+}
+
+#[test]
+fn get_liquid_price_work() {
+    ExtBuilder::default().build().execute_with(|| {
+        assert_eq!(
+            Prices::get_price(&CurrencyId::KSM),
+            Some((Price::from_inner(500 * 1_000_000 * PRICE_ONE), 0))
+        );
+
+        assert_eq!(
+            Prices::get_price(&CurrencyId::xKSM),
+            LiquidStakingExchangeRateProvider::get_exchange_rate()
+                .checked_mul_int(500 * 1_000_000 * PRICE_ONE)
+                .map(|i| (Price::from_inner(i), 0))
+        );
     });
 }

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -168,3 +168,6 @@ impl<T: Config, CurrencyId, AccountId, Balance> XTransfer<T, CurrencyId, Account
         Ok(().into())
     }
 }
+pub trait ExchangeRateProvider {
+    fn get_exchange_rate() -> Rate;
+}

--- a/runtime/heiko/src/lib.rs
+++ b/runtime/heiko/src/lib.rs
@@ -28,7 +28,7 @@ use frame_support::{
     PalletId,
 };
 use orml_currencies::BasicCurrencyAdapter;
-use orml_traits::{parameter_type_with_key, DataProvider};
+use orml_traits::{parameter_type_with_key, DataProvider, DataProviderExtended};
 use polkadot_runtime_common::SlowAdjustingFeeUpdate;
 use sp_api::impl_runtime_apis;
 use sp_core::{
@@ -736,10 +736,30 @@ impl DataProvider<CurrencyId, TimeStampedPrice> for AggregatedDataProvider {
     }
 }
 
+impl DataProviderExtended<CurrencyId, TimeStampedPrice> for AggregatedDataProvider {
+    fn get_no_op(key: &CurrencyId) -> Option<TimeStampedPrice> {
+        Oracle::get_no_op(key)
+    }
+    #[allow(clippy::complexity)]
+    fn get_all_values() -> Vec<(CurrencyId, Option<TimeStampedPrice>)> {
+        Oracle::get_all_values()
+    }
+}
+
 impl pallet_prices::Config for Runtime {
     type Event = Event;
     type Source = AggregatedDataProvider;
     type FeederOrigin = EnsureRoot<AccountId>;
+    type StakingCurrency = StakingCurrency;
+    type LiquidCurrency = LiquidCurrency;
+    type LiquidStakingExchangeRateProvider = LiquidStakingExchangeRateProvider;
+}
+
+pub struct LiquidStakingExchangeRateProvider;
+impl ExchangeRateProvider for LiquidStakingExchangeRateProvider {
+    fn get_exchange_rate() -> Rate {
+        LiquidStaking::exchange_rate()
+    }
 }
 
 parameter_types! {
@@ -1190,13 +1210,13 @@ impl_runtime_apis! {
     > for Runtime {
         fn get_value(provider_id: DataProviderId, key: CurrencyId) -> Option<TimeStampedPrice> {
             match provider_id {
-                DataProviderId::Aggregated => Oracle::get_no_op(&key)
+                DataProviderId::Aggregated => Prices::get_no_op(&key)
             }
         }
 
         fn get_all_values(provider_id: DataProviderId) -> Vec<(CurrencyId, Option<TimeStampedPrice>)> {
             match provider_id {
-                DataProviderId::Aggregated => Oracle::get_all_values()
+                DataProviderId::Aggregated => Prices::get_all_values()
             }
         }
     }

--- a/runtime/heiko/src/lib.rs
+++ b/runtime/heiko/src/lib.rs
@@ -752,14 +752,7 @@ impl pallet_prices::Config for Runtime {
     type FeederOrigin = EnsureRoot<AccountId>;
     type StakingCurrency = StakingCurrency;
     type LiquidCurrency = LiquidCurrency;
-    type LiquidStakingExchangeRateProvider = LiquidStakingExchangeRateProvider;
-}
-
-pub struct LiquidStakingExchangeRateProvider;
-impl ExchangeRateProvider for LiquidStakingExchangeRateProvider {
-    fn get_exchange_rate() -> Rate {
-        LiquidStaking::exchange_rate()
-    }
+    type LiquidStakingExchangeRateProvider = LiquidStaking;
 }
 
 parameter_types! {

--- a/runtime/parallel/src/lib.rs
+++ b/runtime/parallel/src/lib.rs
@@ -27,7 +27,7 @@ use frame_support::{
     PalletId,
 };
 use orml_currencies::BasicCurrencyAdapter;
-use orml_traits::{parameter_type_with_key, DataProvider};
+use orml_traits::{parameter_type_with_key, DataProvider, DataProviderExtended};
 use polkadot_runtime_common::SlowAdjustingFeeUpdate;
 use sp_api::impl_runtime_apis;
 use sp_core::{
@@ -735,11 +735,32 @@ impl DataProvider<CurrencyId, TimeStampedPrice> for AggregatedDataProvider {
     }
 }
 
+impl DataProviderExtended<CurrencyId, TimeStampedPrice> for AggregatedDataProvider {
+    fn get_no_op(key: &CurrencyId) -> Option<TimeStampedPrice> {
+        Oracle::get_no_op(key)
+    }
+    #[allow(clippy::complexity)]
+    fn get_all_values() -> Vec<(CurrencyId, Option<TimeStampedPrice>)> {
+        Oracle::get_all_values()
+    }
+}
+
 impl pallet_prices::Config for Runtime {
     type Event = Event;
     type Source = AggregatedDataProvider;
     type FeederOrigin = EnsureRoot<AccountId>;
+    type StakingCurrency = StakingCurrency;
+    type LiquidCurrency = LiquidCurrency;
+    type LiquidStakingExchangeRateProvider = LiquidStakingExchangeRateProvider;
 }
+
+pub struct LiquidStakingExchangeRateProvider;
+impl ExchangeRateProvider for LiquidStakingExchangeRateProvider {
+    fn get_exchange_rate() -> Rate {
+        LiquidStaking::exchange_rate()
+    }
+}
+
 parameter_types! {
     // One storage item; key size is 32; value is size 4+4+16+32 bytes = 56 bytes.
     pub const DepositBase: Balance = deposit(1, 88);
@@ -1188,13 +1209,13 @@ impl_runtime_apis! {
     > for Runtime {
         fn get_value(provider_id: DataProviderId, key: CurrencyId) -> Option<TimeStampedPrice> {
             match provider_id {
-                DataProviderId::Aggregated => Oracle::get_no_op(&key)
+                DataProviderId::Aggregated => Prices::get_no_op(&key)
             }
         }
 
         fn get_all_values(provider_id: DataProviderId) -> Vec<(CurrencyId, Option<TimeStampedPrice>)> {
             match provider_id {
-                DataProviderId::Aggregated => Oracle::get_all_values()
+                DataProviderId::Aggregated => Prices::get_all_values()
             }
         }
     }

--- a/runtime/parallel/src/lib.rs
+++ b/runtime/parallel/src/lib.rs
@@ -751,14 +751,7 @@ impl pallet_prices::Config for Runtime {
     type FeederOrigin = EnsureRoot<AccountId>;
     type StakingCurrency = StakingCurrency;
     type LiquidCurrency = LiquidCurrency;
-    type LiquidStakingExchangeRateProvider = LiquidStakingExchangeRateProvider;
-}
-
-pub struct LiquidStakingExchangeRateProvider;
-impl ExchangeRateProvider for LiquidStakingExchangeRateProvider {
-    fn get_exchange_rate() -> Rate {
-        LiquidStaking::exchange_rate()
-    }
+    type LiquidStakingExchangeRateProvider = LiquidStaking;
 }
 
 parameter_types! {

--- a/runtime/vanilla/src/lib.rs
+++ b/runtime/vanilla/src/lib.rs
@@ -589,14 +589,7 @@ impl pallet_prices::Config for Runtime {
     type FeederOrigin = EnsureRoot<AccountId>;
     type StakingCurrency = StakingCurrency;
     type LiquidCurrency = LiquidCurrency;
-    type LiquidStakingExchangeRateProvider = LiquidStakingExchangeRateProvider;
-}
-
-pub struct LiquidStakingExchangeRateProvider;
-impl ExchangeRateProvider for LiquidStakingExchangeRateProvider {
-    fn get_exchange_rate() -> Rate {
-        LiquidStaking::exchange_rate()
-    }
+    type LiquidStakingExchangeRateProvider = LiquidStaking;
 }
 
 parameter_types! {

--- a/runtime/vanilla/src/lib.rs
+++ b/runtime/vanilla/src/lib.rs
@@ -51,7 +51,7 @@ use sp_version::RuntimeVersion;
 
 // Import ORML dependcies
 use orml_currencies::BasicCurrencyAdapter;
-use orml_traits::{parameter_type_with_key, DataProvider};
+use orml_traits::{parameter_type_with_key, DataProvider, DataProviderExtended};
 
 // Import Parallel dependencies
 /// Constant values used within the runtime.
@@ -566,17 +566,37 @@ impl pallet_loans::Config for Runtime {
     type UnixTime = Timestamp;
 }
 
-pub type TimeStampedPrice = orml_oracle::TimestampedValue<PriceWithDecimal, Moment>;
 pub struct AggregatedDataProvider;
 impl DataProvider<CurrencyId, TimeStampedPrice> for AggregatedDataProvider {
     fn get(key: &CurrencyId) -> Option<TimeStampedPrice> {
         Oracle::get(key)
     }
 }
+
+impl DataProviderExtended<CurrencyId, TimeStampedPrice> for AggregatedDataProvider {
+    fn get_no_op(key: &CurrencyId) -> Option<TimeStampedPrice> {
+        Oracle::get_no_op(key)
+    }
+    #[allow(clippy::complexity)]
+    fn get_all_values() -> Vec<(CurrencyId, Option<TimeStampedPrice>)> {
+        Oracle::get_all_values()
+    }
+}
+
 impl pallet_prices::Config for Runtime {
     type Event = Event;
     type Source = AggregatedDataProvider;
     type FeederOrigin = EnsureRoot<AccountId>;
+    type StakingCurrency = StakingCurrency;
+    type LiquidCurrency = LiquidCurrency;
+    type LiquidStakingExchangeRateProvider = LiquidStakingExchangeRateProvider;
+}
+
+pub struct LiquidStakingExchangeRateProvider;
+impl ExchangeRateProvider for LiquidStakingExchangeRateProvider {
+    fn get_exchange_rate() -> Rate {
+        LiquidStaking::exchange_rate()
+    }
 }
 
 parameter_types! {
@@ -887,13 +907,13 @@ impl_runtime_apis! {
     > for Runtime {
         fn get_value(provider_id: DataProviderId, key: CurrencyId) -> Option<TimeStampedPrice> {
             match provider_id {
-                DataProviderId::Aggregated => Oracle::get_no_op(&key)
+                DataProviderId::Aggregated => Prices::get_no_op(&key)
             }
         }
 
         fn get_all_values(provider_id: DataProviderId) -> Vec<(CurrencyId, Option<TimeStampedPrice>)> {
             match provider_id {
-                DataProviderId::Aggregated => Oracle::get_all_values()
+                DataProviderId::Aggregated => Prices::get_all_values()
             }
         }
     }


### PR DESCRIPTION
Now the price of xKSM will calculate according to KSM and exchangeRate. I haven't delete xKSM in Oracle-client since the frontend will get price directly from `oracle pallet`. 