### PR TITLE
Fix/broken chainspec

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -6,8 +6,6 @@ relaychain:
       config:
         validation_upgrade_frequency: 1
         validation_upgrade_delay: 1
-  env:
-    RUST_LOG: parachain::candidate-backing=trace,parachain::candidate-selection=trace,parachain::pvf=trace,parachain::collator-protocol=trace,parachain::provisioner=trace
   flags:
     - --rpc-methods=unsafe
     - --wasm-execution=compiled
@@ -38,8 +36,6 @@ parachains:
       - --wasm-execution=compiled
       - --execution=wasm
       - --no-beefy
-    env:
-      RUST_LOG: sc_basic_authorship=trace,cumulus-consensus=trace,cumulus-collator=trace,collator_protocol=trace,collation_generation=trace,aura=debug
     nodes:
       - flags:
           - --alice

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,14 +15,10 @@ services:
     ports:
       - "8080:80"
     image: parallelfinance/parallel-dapp:latest
-    links:
-      - "parallel:parallel"
     restart: always
 
   oracle:
     image: parallelfinance/oracle-client:latest
-    links:
-      - "parallel:parallel"
     command: start -w ws://parallel:9944
     restart: always
 

--- a/node/parallel-dev/src/chain_spec.rs
+++ b/node/parallel-dev/src/chain_spec.rs
@@ -185,7 +185,7 @@ fn testnet_genesis(
 
                 endowed_accounts
                     .into_iter()
-                    .map(|k| (k, 10_u128.pow(21)))
+                    .map(|k| (k, 10_u128.pow(16)))
                     .collect()
             },
         },
@@ -199,8 +199,8 @@ fn testnet_genesis(
                         .unwrap()
                     {
                         vec![
-                            (x.clone(), CurrencyId::KSM, 10_u128.pow(21)),
-                            (x.clone(), CurrencyId::USDT, 10_u128.pow(15)),
+                            (x.clone(), CurrencyId::KSM, 10_u128.pow(20)),
+                            (x.clone(), CurrencyId::USDT, 10_u128.pow(14)),
                         ]
                     } else {
                         vec![

--- a/node/parallel/src/chain_spec/heiko.rs
+++ b/node/parallel/src/chain_spec/heiko.rs
@@ -210,7 +210,7 @@ fn testnet_genesis(
 
                 endowed_accounts
                     .into_iter()
-                    .map(|k| (k, 10_u128.pow(15)))
+                    .map(|k| (k, 10_u128.pow(16)))
                     .collect()
             },
         },
@@ -246,8 +246,8 @@ fn testnet_genesis(
                         .unwrap()
                     {
                         vec![
-                            (x.clone(), CurrencyId::KSM, 10_u128.pow(21)),
-                            (x.clone(), CurrencyId::USDT, 10_u128.pow(15)),
+                            (x.clone(), CurrencyId::KSM, 10_u128.pow(20)),
+                            (x.clone(), CurrencyId::USDT, 10_u128.pow(14)),
                         ]
                     } else {
                         vec![

--- a/node/parallel/src/chain_spec/parallel.rs
+++ b/node/parallel/src/chain_spec/parallel.rs
@@ -212,7 +212,7 @@ fn testnet_genesis(
 
                 endowed_accounts
                     .into_iter()
-                    .map(|k| (k, 10_u128.pow(13)))
+                    .map(|k| (k, 10_u128.pow(16)))
                     .collect()
             },
         },
@@ -248,8 +248,8 @@ fn testnet_genesis(
                         .unwrap()
                     {
                         vec![
-                            (x.clone(), CurrencyId::DOT, 10_u128.pow(13)),
-                            (x.clone(), CurrencyId::USDT, 10_u128.pow(15)),
+                            (x.clone(), CurrencyId::DOT, 10_u128.pow(20)),
+                            (x.clone(), CurrencyId::USDT, 10_u128.pow(16)),
                         ]
                     } else {
                         vec![


### PR DESCRIPTION
1e21 is too big for javascript and it'll break the chainspec generated by parachain-launch because:



![image](https://user-images.githubusercontent.com/33961674/127804551-11f81b36-a5be-4d2a-95fe-d8d04f5c966a.png)

and serde_json cannot pase `1e+21`

I changed `1e21` to `1e20`, the default native balance is `10000`