### PR TITLE
basic insurance pool

### DIFF
--- a/pallets/liquid-staking/src/lib.rs
+++ b/pallets/liquid-staking/src/lib.rs
@@ -624,6 +624,14 @@ pub mod pallet {
                 },
             )?;
 
+            let xcm_weight = T::BaseXcmWeight::get() as Balance;
+            TotalReserves::<T>::try_mutate(|b| -> DispatchResult {
+                *b = b
+                    .checked_sub(xcm_weight)
+                    .ok_or(ArithmeticError::Underflow)?;
+                Ok(())
+            })?;
+
             T::Currency::transfer(
                 T::StakingCurrency::get(),
                 &Self::account_id(),

--- a/pallets/liquid-staking/src/lib.rs
+++ b/pallets/liquid-staking/src/lib.rs
@@ -116,8 +116,6 @@ pub mod pallet {
 
     #[pallet::error]
     pub enum Error<T> {
-        /// The withdraw exceeded the current pool balance
-        ExcessPoolBalance,
         /// ExchangeRate is invalid
         InvalidExchangeRate,
         /// The withdraw assets exceed the threshold
@@ -341,11 +339,6 @@ pub mod pallet {
         ) -> DispatchResultWithPostInfo {
             T::WithdrawOrigin::ensure_origin(origin)?;
             ensure!(T::Members::contains(&agent), Error::<T>::IllegalAgent);
-
-            ensure!(
-                amount <= TotalStakingAsset::<T>::get(),
-                Error::<T>::ExcessPoolBalance
-            );
 
             ensure!(
                 amount <= T::MaxWithdrawAmount::get(),

--- a/pallets/liquid-staking/src/lib.rs
+++ b/pallets/liquid-staking/src/lib.rs
@@ -451,12 +451,12 @@ pub mod pallet {
                 ExchangeRate::<T>::put(exchange_rate);
             }
 
-            TotalReserves::<T>::put(left_reserves);
             T::Currency::withdraw(
                 T::StakingCurrency::get(),
                 &Self::account_id(),
                 reduced_reserves,
             )?;
+            TotalReserves::<T>::put(left_reserves);
 
             Self::deposit_event(Event::SlashRecorded(agent, amount));
             Ok(().into())
@@ -502,7 +502,7 @@ pub mod pallet {
                 *b = b.checked_sub(amount).ok_or(ArithmeticError::Underflow)?;
                 Ok(())
             })?;
-            // TODO should it update after applied onbond operation?
+            // TODO should it update after applied unbond operation?
             TotalStakingAsset::<T>::try_mutate(|b| -> DispatchResult {
                 *b = b
                     .checked_sub(asset_amount)

--- a/pallets/liquid-staking/src/lib.rs
+++ b/pallets/liquid-staking/src/lib.rs
@@ -116,6 +116,8 @@ pub mod pallet {
 
     #[pallet::error]
     pub enum Error<T> {
+        /// The withdraw exceeded the current pool balance
+        ExcessPoolBalance,
         /// ExchangeRate is invalid
         InvalidExchangeRate,
         /// The withdraw assets exceed the threshold
@@ -341,6 +343,11 @@ pub mod pallet {
             ensure!(T::Members::contains(&agent), Error::<T>::IllegalAgent);
 
             ensure!(
+                amount <= TotalStakingAsset::<T>::get(),
+                Error::<T>::ExcessPoolBalance
+            );
+
+            ensure!(
                 amount <= T::MaxWithdrawAmount::get(),
                 Error::<T>::ExcessWithdrawThreshold
             );
@@ -354,7 +361,6 @@ pub mod pallet {
                     .ok_or(ArithmeticError::Underflow)?;
                 Ok(())
             })?;
-            T::Currency::withdraw(T::StakingCurrency::get(), &Self::account_id(), xcm_weight)?;
 
             let xcm_amount = amount
                 .checked_add(xcm_weight)

--- a/pallets/liquid-staking/src/mock.rs
+++ b/pallets/liquid-staking/src/mock.rs
@@ -26,6 +26,7 @@ pub const DOT: CurrencyId = CurrencyId::DOT;
 pub const XDOT: CurrencyId = CurrencyId::xDOT;
 pub const NATIVE: CurrencyId = CurrencyId::HKO;
 pub const DOT_DECIMAL: u128 = 10u128.pow(10);
+
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 type BlockNumber = u64;
@@ -247,7 +248,7 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
         .unwrap();
     orml_tokens::GenesisConfig::<Test> {
         balances: vec![
-            (1.into(), CurrencyId::DOT, 100),
+            (1.into(), CurrencyId::DOT, 100 * DOT_DECIMAL),
             (11.into(), CurrencyId::DOT, 100 * DOT_DECIMAL),
         ],
     }

--- a/pallets/liquid-staking/src/mock.rs
+++ b/pallets/liquid-staking/src/mock.rs
@@ -180,9 +180,9 @@ parameter_types! {
     pub const LiquidStakingPalletId: PalletId = PalletId(*b"par/lqsk");
     pub const StakingCurrency: CurrencyId = DOT;
     pub const LiquidCurrency: CurrencyId = XDOT;
-    pub const MaxWithdrawAmount: Balance = 10;
+    pub const MaxWithdrawAmount: Balance = 10 * DOT_DECIMAL;
     pub const MaxAccountProcessingUnstake: u32 = 5;
-    pub const BaseXcmWeight: Weight = 0;
+    pub const BaseXcmWeight: Weight = 100_000_000;
 }
 
 impl pallet_liquid_staking::Config for Test {

--- a/pallets/liquid-staking/src/tests.rs
+++ b/pallets/liquid-staking/src/tests.rs
@@ -698,7 +698,7 @@ fn record_rewards_deduct_reserve_should_work() {
         assert_eq!(TotalStakingAsset::<Test>::get(), total_staking);
         let total_voucher = 500 * DOT_DECIMAL;
         assert_eq!(TotalVoucher::<Test>::get(), total_voucher);
-        assert_eq!(TotalReserve::<Test>::get(), 5 * 10u128.pow(7));
+        assert_eq!(TotalReserves::<Test>::get(), 5 * 10u128.pow(7));
         assert_eq!(
             ExchangeRate::<Test>::get(),
             Rate::saturating_from_rational(total_staking, total_voucher)

--- a/pallets/loans/src/lib.rs
+++ b/pallets/loans/src/lib.rs
@@ -148,8 +148,8 @@ pub mod pallet {
         InsufficientReserves,
         /// Invalid rate model params
         InvalidRateModelParam,
-        /// Currency not enabled
-        CurrencyNotEnabled,
+        /// Market not activated
+        MarketNotActivated,
         /// Currency's oracle price not ready
         PriceOracleNotReady,
         /// Market does not exist
@@ -1253,7 +1253,7 @@ impl<T: Config> Pallet<T> {
         if Self::active_markets().any(|(currency, _)| &currency == currency_id) {
             Ok(())
         } else {
-            Err(<Error<T>>::CurrencyNotEnabled.into())
+            Err(<Error<T>>::MarketNotActivated.into())
         }
     }
 

--- a/pallets/loans/src/tests/liquidate_borrow.rs
+++ b/pallets/loans/src/tests/liquidate_borrow.rs
@@ -136,7 +136,7 @@ fn liquidator_cannot_take_inactive_market_currency() {
         }));
         assert_noop!(
             Loans::liquidate_borrow(Origin::signed(BOB), ALICE, KSM, million_dollar(50), DOT),
-            Error::<Runtime>::CurrencyNotEnabled
+            Error::<Runtime>::MarketNotActivated
         );
     })
 }

--- a/runtime/heiko/src/constants.rs
+++ b/runtime/heiko/src/constants.rs
@@ -47,8 +47,8 @@ pub mod time {
 /// Fee-related.
 pub mod fee {
     use frame_support::weights::{
-        constants::ExtrinsicBaseWeight, WeightToFeeCoefficient, WeightToFeeCoefficients,
-        WeightToFeePolynomial,
+        constants::{ExtrinsicBaseWeight, WEIGHT_PER_SECOND},
+        WeightToFeeCoefficient, WeightToFeeCoefficients, WeightToFeePolynomial,
     };
     use primitives::Balance;
     use smallvec::smallvec;
@@ -72,7 +72,8 @@ pub mod fee {
         type Balance = Balance;
         fn polynomial() -> WeightToFeeCoefficients<Self::Balance> {
             // in Kusama, extrinsic base weight (smallest non-zero weight) is mapped to 1/10 CENT:
-            // in Statemine, we map to 1/10 of that, or 1/100 CENT
+            // in Statemine, it's mapped to 1/10 of that, or 1/100 CENT
+            // in Heiko, it's mapped to 1/100 CENT
             let p = super::currency::CENTS;
             let q = 100 * Balance::from(ExtrinsicBaseWeight::get());
             smallvec![WeightToFeeCoefficient {
@@ -82,5 +83,12 @@ pub mod fee {
                 coeff_integer: p / q,
             }]
         }
+    }
+
+    pub fn ksm_per_second() -> u128 {
+        let base_weight = Balance::from(ExtrinsicBaseWeight::get());
+        let base_tx_per_second = (WEIGHT_PER_SECOND as u128) / base_weight;
+        let hko_per_second = base_tx_per_second * super::currency::CENTS / 10;
+        hko_per_second / 100
     }
 }

--- a/runtime/heiko/src/lib.rs
+++ b/runtime/heiko/src/lib.rs
@@ -27,7 +27,7 @@ use frame_support::{
     PalletId,
 };
 use orml_currencies::BasicCurrencyAdapter;
-use orml_traits::{parameter_type_with_key, DataProvider, DataProviderExtended};
+use orml_traits::{parameter_type_with_key, DataProvider, DataProviderExtended, MultiCurrency};
 use polkadot_runtime_common::SlowAdjustingFeeUpdate;
 use sp_api::impl_runtime_apis;
 use sp_core::{
@@ -60,10 +60,11 @@ use primitives::*;
 use static_assertions::const_assert;
 use xcm::v0::{Junction, Junction::*, MultiAsset, MultiLocation, MultiLocation::*, NetworkId, Xcm};
 use xcm_builder::{
-    AccountId32Aliases, AllowTopLevelPaidExecutionFrom, EnsureXcmOrigin, FixedWeightBounds,
-    LocationInverter, ParentAsSuperuser, ParentIsDefault, RelayChainAsNative,
-    SiblingParachainAsNative, SiblingParachainConvertsVia, SignedAccountId32AsNative,
-    SignedToAccountId32, SovereignSignedViaLocation, TakeWeightCredit, UsingComponents,
+    AccountId32Aliases, AllowTopLevelPaidExecutionFrom, EnsureXcmOrigin,
+    FixedRateOfConcreteFungible, FixedWeightBounds, LocationInverter, ParentAsSuperuser,
+    ParentIsDefault, RelayChainAsNative, SiblingParachainAsNative, SiblingParachainConvertsVia,
+    SignedAccountId32AsNative, SignedToAccountId32, SovereignSignedViaLocation, TakeRevenue,
+    TakeWeightCredit,
 };
 use xcm_executor::{Config, XcmExecutor};
 
@@ -421,6 +422,21 @@ impl pallet_liquid_staking::Config for Runtime {
 }
 
 parameter_types! {
+    pub StakingPoolAccount: AccountId = StakingPalletId::get().into_account();
+}
+
+pub struct ToStakingPool;
+impl TakeRevenue for ToStakingPool {
+    fn take_revenue(revenue: MultiAsset) {
+        if let MultiAsset::ConcreteFungible { id, amount } = revenue {
+            if let Some(currency_id) = CurrencyIdConvert::convert(id) {
+                let _ = Currencies::deposit(currency_id, &StakingPoolAccount::get(), amount);
+            }
+        }
+    }
+}
+
+parameter_types! {
     pub const LockPeriod: u64 = 20000; // in milli-seconds
     pub const LiquidateFactor: Percent = Percent::from_percent(50);
 }
@@ -718,6 +734,7 @@ pub type XcmOriginToTransactDispatchOrigin = (
 
 parameter_types! {
     pub UnitWeightCost: Weight = 1_000;
+    pub KsmPerSecond: (MultiLocation, u128) = (X1(Parent), ksm_per_second());
 }
 
 parameter_types! {
@@ -745,7 +762,7 @@ impl Config for XcmConfig {
     type LocationInverter = LocationInverter<Ancestry>;
     type Barrier = Barrier;
     type Weigher = FixedWeightBounds<UnitWeightCost, Call>;
-    type Trader = UsingComponents<IdentityFee<Balance>, RelayLocation, AccountId, Balances, ()>;
+    type Trader = FixedRateOfConcreteFungible<KsmPerSecond, ToStakingPool>;
     type ResponseHandler = (); // Don't handle responses for now.
 }
 

--- a/runtime/parallel/src/constants.rs
+++ b/runtime/parallel/src/constants.rs
@@ -47,8 +47,8 @@ pub mod time {
 /// Fee-related.
 pub mod fee {
     use frame_support::weights::{
-        constants::ExtrinsicBaseWeight, WeightToFeeCoefficient, WeightToFeeCoefficients,
-        WeightToFeePolynomial,
+        constants::{ExtrinsicBaseWeight, WEIGHT_PER_SECOND},
+        WeightToFeeCoefficient, WeightToFeeCoefficients, WeightToFeePolynomial,
     };
     use primitives::Balance;
     use smallvec::smallvec;
@@ -72,7 +72,8 @@ pub mod fee {
         type Balance = Balance;
         fn polynomial() -> WeightToFeeCoefficients<Self::Balance> {
             // in Kusama, extrinsic base weight (smallest non-zero weight) is mapped to 1/10 CENT:
-            // in Statemine, we map to 1/10 of that, or 1/100 CENT
+            // in Statemine, it's mapped to 1/10 of that, or 1/100 CENT
+            // in Parallel, it's mapped to 1/100 CENT
             let p = super::currency::CENTS;
             let q = 100 * Balance::from(ExtrinsicBaseWeight::get());
             smallvec![WeightToFeeCoefficient {
@@ -82,5 +83,12 @@ pub mod fee {
                 coeff_integer: p / q,
             }]
         }
+    }
+
+    pub fn dot_per_second() -> u128 {
+        let base_weight = Balance::from(ExtrinsicBaseWeight::get());
+        let base_tx_per_second = (WEIGHT_PER_SECOND as u128) / base_weight;
+        let para_per_second = base_tx_per_second * super::currency::CENTS / 10;
+        para_per_second / 10
     }
 }

--- a/runtime/parallel/src/lib.rs
+++ b/runtime/parallel/src/lib.rs
@@ -27,7 +27,7 @@ use frame_support::{
     PalletId,
 };
 use orml_currencies::BasicCurrencyAdapter;
-use orml_traits::{parameter_type_with_key, DataProvider, DataProviderExtended};
+use orml_traits::{parameter_type_with_key, DataProvider, DataProviderExtended, MultiCurrency};
 use polkadot_runtime_common::SlowAdjustingFeeUpdate;
 use sp_api::impl_runtime_apis;
 use sp_core::{
@@ -62,10 +62,11 @@ use primitives::*;
 use static_assertions::const_assert;
 use xcm::v0::{Junction, Junction::*, MultiAsset, MultiLocation, MultiLocation::*, NetworkId, Xcm};
 use xcm_builder::{
-    AccountId32Aliases, AllowTopLevelPaidExecutionFrom, EnsureXcmOrigin, FixedWeightBounds,
-    LocationInverter, ParentAsSuperuser, ParentIsDefault, RelayChainAsNative,
-    SiblingParachainAsNative, SiblingParachainConvertsVia, SignedAccountId32AsNative,
-    SignedToAccountId32, SovereignSignedViaLocation, TakeWeightCredit, UsingComponents,
+    AccountId32Aliases, AllowTopLevelPaidExecutionFrom, EnsureXcmOrigin,
+    FixedRateOfConcreteFungible, FixedWeightBounds, LocationInverter, ParentAsSuperuser,
+    ParentIsDefault, RelayChainAsNative, SiblingParachainAsNative, SiblingParachainConvertsVia,
+    SignedAccountId32AsNative, SignedToAccountId32, SovereignSignedViaLocation, TakeRevenue,
+    TakeWeightCredit,
 };
 use xcm_executor::{Config, XcmExecutor};
 
@@ -397,6 +398,21 @@ impl pallet_liquid_staking::Config for Runtime {
 }
 
 parameter_types! {
+    pub StakingPoolAccount: AccountId = StakingPalletId::get().into_account();
+}
+
+pub struct ToStakingPool;
+impl TakeRevenue for ToStakingPool {
+    fn take_revenue(revenue: MultiAsset) {
+        if let MultiAsset::ConcreteFungible { id, amount } = revenue {
+            if let Some(currency_id) = CurrencyIdConvert::convert(id) {
+                let _ = Currencies::deposit(currency_id, &StakingPoolAccount::get(), amount);
+            }
+        }
+    }
+}
+
+parameter_types! {
     pub const MaxValidators: u32 = 16;
     pub const ValidatorFeedersMembershipMaxMembers: u32 = 3;
 }
@@ -719,7 +735,8 @@ pub type XcmOriginToTransactDispatchOrigin = (
 );
 
 parameter_types! {
-    pub UnitWeightCost: Weight = 1_000;
+    pub UnitWeightCost: Weight = 200_000_000;
+    pub KsmPerSecond: (MultiLocation, u128) = (X1(Parent), dot_per_second());
 }
 
 parameter_types! {
@@ -747,7 +764,7 @@ impl Config for XcmConfig {
     type LocationInverter = LocationInverter<Ancestry>;
     type Barrier = Barrier;
     type Weigher = FixedWeightBounds<UnitWeightCost, Call>;
-    type Trader = UsingComponents<IdentityFee<Balance>, RelayLocation, AccountId, Balances, ()>;
+    type Trader = FixedRateOfConcreteFungible<KsmPerSecond, ToStakingPool>;
     type ResponseHandler = (); // Don't handle responses for now.
 }
 


### PR DESCRIPTION
the insurance pool should cover xcm fees and try to cover maximum slashes

close: #350 
close: #340 

it'll charge staking fees & xcm fees while users stake, then when the stake-client withdraw it'll try to pay the xcm fees, when slashes happen it'll also pay as much as possible.

when user unstake and in the final step, it'll also pay the xcm fees

**Important**: I'm not yet happy to use this approach as it makes the xcm amount more complex. I still suggest #355, I'll raise maybe new pr to solve #350, and use insurance pool to cover only slashes

the xcm fees we may need to find another solution