### PR TITLE
Fix typo mistake of metadata

### DIFF
--- a/pallets/liquid-staking-v2/src/lib.rs
+++ b/pallets/liquid-staking-v2/src/lib.rs
@@ -108,7 +108,7 @@ mod pallet {
 
     #[pallet::event]
     #[pallet::generate_deposit(pub(super) fn deposit_event)]
-    #[pallet::metadata(T::AccountId = "Account", BalanceOf<T> = "Balance")]
+    #[pallet::metadata(T::AccountId = "AccountId", BalanceOf<T> = "Balance")]
     pub enum Event<T: Config> {
         /// The assets get staked successfully
         Staked(T::AccountId, BalanceOf<T>),


### PR DESCRIPTION
Fix a typo mistake of `AccountId`