### PR TITLE
Update rustdoc.yml

### DIFF
--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        rust: [nightly-2021-05-03]
+        rust: [nightly-2021-09-07]
 
     steps:
       - name: Checkout Repository


### PR DESCRIPTION
nightly-2021-05-03 can not compile successfully,
should upgrade the nightly version to include the [from_str](https://doc.rust-lang.org/nightly/proc_macro/struct.Literal.html#method.from_str) function.
***
![ci rustdoc yml bug](https://user-images.githubusercontent.com/26266313/132460073-1e4576b5-73ca-41c6-9296-296db5cc6d57.jpg)
