### PR TITLE
convert spec to code and setup testing framework

### DIFF
--- a/pallets/crowdloans/Cargo.toml
+++ b/pallets/crowdloans/Cargo.toml
@@ -1,0 +1,42 @@
+[package]
+authors = ['Parallel Team']
+edition = '2018'
+name    = 'pallet-crowdloans'
+version = '3.0.0'
+
+[package.metadata.docs.rs]
+targets = ['x86_64-unknown-linux-gnu']
+
+[dependencies]
+codec              = { package = 'parity-scale-codec', version = '2.0.0', features = ['max-encoded-len'], default-features = false }
+frame-benchmarking = { git = 'https://github.com/paritytech/substrate.git', branch = 'polkadot-v0.9.9', default-features = false, optional = true }
+frame-support      = { git = 'https://github.com/paritytech/substrate', branch = 'polkadot-v0.9.9', default-features = false }
+frame-system       = { git = 'https://github.com/paritytech/substrate', branch = 'polkadot-v0.9.9', default-features = false }
+pallet-assets      = { git = 'https://github.com/paritytech/substrate', branch = 'polkadot-v0.9.9', default-features = false }
+primitives         = { package = 'parallel-primitives', path = '../../primitives', default-features = false }
+serde              = { version = '1', features = ['derive'], optional = true }
+sp-arithmetic      = { git = 'https://github.com/paritytech/substrate', branch = 'polkadot-v0.9.9', default-features = false }
+sp-runtime         = { git = 'https://github.com/paritytech/substrate', branch = 'polkadot-v0.9.9', default-features = false }
+sp-std             = { git = 'https://github.com/paritytech/substrate', branch = 'polkadot-v0.9.9', default-features = false }
+
+[dev-dependencies]
+pallet-balances = { branch = 'polkadot-v0.9.9', git = 'https://github.com/paritytech/substrate' }
+sp-core         = { branch = 'polkadot-v0.9.9', git = 'https://github.com/paritytech/substrate' }
+sp-io           = { branch = 'polkadot-v0.9.9', git = 'https://github.com/paritytech/substrate' }
+
+[features]
+default            = ['std']
+runtime-benchmarks = ['frame-benchmarking']
+std                = [
+  'serde',
+  'codec/std',
+  'frame-benchmarking/std',
+  'frame-support/std',
+  'frame-system/std',
+  'primitives/std',
+  'sp-arithmetic/std',
+  'sp-runtime/std',
+  'sp-std/std',
+  'pallet-assets/std',
+]
+try-runtime        = ['frame-support/try-runtime']

--- a/pallets/crowdloans/src/crowdloan_structs.rs
+++ b/pallets/crowdloans/src/crowdloan_structs.rs
@@ -1,0 +1,54 @@
+// Copyright 2021 Parallel Finance Developer.
+// This file is part of Parallel Finance.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Groups common pool related structures
+
+use primitives::{currency::CurrencyId, AssetId, Balance, BlockNumber};
+
+#[cfg_attr(feature = "std", derive(serde::Deserialize, serde::Serialize))]
+#[derive(Clone, PartialEq, codec::Decode, codec::Encode, sp_runtime::RuntimeDebug)]
+pub enum VaultPhase {
+    /// Vault is open for contributions until the included block number
+    CollectingContributionsUntil(BlockNumber),
+    /// The vault's assets have been contributed to its associated crowdloan
+    Participated,
+    /// The vault's crowdloan failed, we have to distribute its assets back
+    /// to the contributors
+    Failed,
+    /// The vault's crowdloan succeeded, project tokens will be identified
+    /// by the provided asset id
+    Succeeded(AssetId),
+    /// The vault's crowdloan succeeded and returned the vault's assets
+    SucceededAndRefunded(AssetId),
+}
+
+#[cfg_attr(feature = "std", derive(serde::Deserialize, serde::Serialize))]
+#[derive(Clone, PartialEq, codec::Decode, codec::Encode, sp_runtime::RuntimeDebug)]
+pub struct Vault {
+    /// Asset used to represent the shares of project tokens for the contributors
+    /// to this vault
+    pub project_shares: AssetId,
+    /// Asset used to represent the shares of currency (typically DOT or KSM)
+    /// to be claimed back later on
+    pub currency_shares: AssetId,
+    /// Indicates in which currency contributions are received, in most
+    /// cases this will be the asset representing the relay chain's native
+    /// token
+    pub currency: CurrencyId,
+    /// Which phase the vault is at
+    pub phase: VaultPhase,
+    /// Amount of shares used to claim project tokens but that weren't used
+    /// to claim the DOT / KSM refund yet
+    pub claimed: Balance,
+}

--- a/pallets/crowdloans/src/lib.rs
+++ b/pallets/crowdloans/src/lib.rs
@@ -1,0 +1,250 @@
+// Copyright 2021 Parallel Finance Developer.
+// This file is part of Parallel Finance.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! # Crowdloans
+//!
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+extern crate alloc;
+
+mod crowdloan_structs;
+use crowdloan_structs::Vault;
+use crowdloan_structs::VaultPhase;
+
+use frame_support::{
+    pallet_prelude::*,
+    traits::{fungibles::Inspect, Get, IsType},
+    Blake2_128Concat, PalletId,
+};
+use frame_system::pallet_prelude::OriginFor;
+pub use pallet::*;
+use primitives::{currency::CurrencyId, Balance};
+
+#[cfg(test)]
+mod mock;
+#[cfg(test)]
+mod tests;
+
+pub type ParaId = u32;
+
+#[frame_support::pallet]
+pub mod pallet {
+    use super::*;
+    use frame_support::traits::tokens::fungibles;
+    use frame_system::ensure_root;
+    use primitives::AssetId;
+
+    use sp_arithmetic::traits::Zero;
+
+    #[pallet::config]
+    pub trait Config<I: 'static = ()>:
+        frame_system::Config + pallet_assets::Config<AssetId = AssetId, Balance = Balance>
+    {
+        type Event: From<Event<Self, I>> + IsType<<Self as frame_system::Config>::Event>;
+
+        /// Currency type for deposit/withdraw assets to/from crowdloan
+        /// module
+        type CrowdloanCurrency: fungibles::Inspect<Self::AccountId, AssetId = CurrencyId, Balance = Balance>
+            + fungibles::Mutate<Self::AccountId, AssetId = CurrencyId, Balance = Balance>
+            + fungibles::Transfer<Self::AccountId, AssetId = CurrencyId, Balance = Balance>;
+
+        #[pallet::constant]
+        type PalletId: Get<PalletId>;
+    }
+
+    #[pallet::error]
+    pub enum Error<T, I = ()> {
+        /// Vault is not in correct phase
+        IncorrectVaultPhase,
+        /// Vault shares are not new
+        SharesNotNew,
+        // Crowdload ParaId aready exists
+        CrowdloanAlreadyExists,
+    }
+
+    #[pallet::event]
+    pub enum Event<T: Config<I>, I: 'static = ()> {
+        /// Create new vault
+        /// [token, crowdloan, project_shares, currency_shares]
+        VaultCreated(CurrencyId, ParaId, AssetId, AssetId),
+    }
+
+    #[pallet::pallet]
+    pub struct Pallet<T, I = ()>(_);
+
+    #[pallet::storage]
+    #[pallet::getter(fn vaults)]
+    pub type Vaults<T, I = ()> = StorageMap<_, Blake2_128Concat, ParaId, Vault, OptionQuery>;
+
+    #[pallet::call]
+    impl<T: Config<I>, I: 'static> Pallet<T, I> {
+        ////
+        //// 1. Vaults Management
+
+        /// - `token` is the currency or token which needs to be deposited to fill
+        ///   the vault and later participate in the crowdloans
+        /// - `crowdloan` represents which crowdloan we are supporting
+        /// - `project_shares` and `currency_shares` are new assets created for this
+        ///   vault to represent the shares of the vault's contributors
+        /// - `until` sets the vault's expiration block, a vault must be "expired"
+        ///   until it can be used to participate in its crowdloan
+        #[pallet::weight(10_000)]
+        #[allow(unused)]
+        pub fn create_vault(
+            origin: OriginFor<T>,
+            token: CurrencyId,
+            crowdloan: ParaId,
+            project_shares: AssetId,
+            currency_shares: AssetId,
+            until: primitives::BlockNumber,
+        ) -> DispatchResult {
+            ensure_root(origin)?;
+
+            // get
+            let project_shares_issuance =
+                T::CrowdloanCurrency::total_issuance(CurrencyId::Asset(project_shares));
+            let currency_shares_issuance =
+                T::CrowdloanCurrency::total_issuance(CurrencyId::Asset(currency_shares));
+
+            // make sure both project_shares and currency_shares are new assets
+            ensure!(
+                project_shares_issuance == Zero::zero() && currency_shares_issuance == Zero::zero(),
+                Error::<T, I>::SharesNotNew
+            );
+
+            // make sure no similar vault already exists as identified by crowdloan
+            ensure!(
+                !Vaults::<T, I>::contains_key(&crowdloan),
+                Error::<T, I>::CrowdloanAlreadyExists
+            );
+
+            // add new vault to vaults storage
+            Vaults::<T, I>::try_mutate(&crowdloan, |vault| -> Result<_, DispatchError> {
+                // inialize new vault
+                Ok(*vault = Some(crowdloan_structs::Vault {
+                    project_shares: project_shares,
+                    currency_shares: currency_shares,
+                    currency: CurrencyId::Asset(currency_shares),
+                    phase: VaultPhase::CollectingContributionsUntil(until),
+                    claimed: 0,
+                }))
+            })
+        }
+
+        ////
+        //// 2. Contribution to Vaults
+
+        /// Contribute `amount` to the vault of `crowdloan` and receive some
+        /// shares from it
+
+        #[pallet::weight(10_000)]
+        #[allow(unused)]
+        pub fn contribute(
+            origin: OriginFor<T>,
+            crowdloan: ParaId,
+            amount: Balance,
+        ) -> DispatchResult {
+            unimplemented!();
+        }
+
+        ////
+        //// 3. Triggering participation in a crowdloan
+
+        /// Once a auction loan vault is expired, move the coins to the relay chain
+        /// and participate in a relay chain crowdloan by using the call `call`.
+        #[pallet::weight(10_000)]
+        #[allow(unused)]
+        pub fn participate_with_call(
+            origin: OriginFor<T>,
+            crowdloan: ParaId,
+            call: Box<u8>, // should be Box<Call> for use with sudo
+        ) -> DispatchResult {
+            ensure_root(origin)?;
+            unimplemented!();
+        }
+
+        ////
+        //// 4. Handling Failed Auctions
+
+        /// If a `crowdloan` failed, use `call` to get the coins back and mark the
+        /// vault as ready for distribution
+        #[pallet::weight(10_000)]
+        #[allow(unused)]
+        pub fn auction_failed(
+            origin: OriginFor<T>,
+            crowdloan: ParaId,
+            call: Box<u8>, // should be Box<Call> for use with sudo
+        ) -> DispatchResult {
+            ensure_root(origin)?;
+            unimplemented!();
+        }
+
+        /// If a `crowdloan` failed, claim back your share of the assets you
+        /// contributed
+        #[pallet::weight(10_000)]
+        #[allow(unused)]
+        pub fn claim_refund(
+            origin: OriginFor<T>,
+            crowdloan: ParaId,
+            amount: Balance,
+        ) -> DispatchResult {
+            unimplemented!();
+        }
+
+        ////
+        //// 5. Distributing Project Tokens
+
+        /// If a `crowdloan` succeeded, use `call` to receive or claim the
+        /// project tokens, can be called many times
+        #[pallet::weight(10_000)]
+        #[allow(unused)]
+        pub fn auction_completed(
+            origin: OriginFor<T>,
+            crowdloan: ParaId,
+            project_token: AssetId,
+            call: Box<u8>, // should be Box<Call> for use with sudo
+        ) -> DispatchResult {
+            ensure_root(origin)?;
+            unimplemented!();
+        }
+
+        /// If a `crowdloan` succeeded, claim your share of the project tokens
+        #[pallet::weight(10_000)]
+        #[allow(unused)]
+        pub fn claim_project_tokens(
+            origin: OriginFor<T>,
+            crowdloan: ParaId,
+            amount: Balance,
+        ) -> DispatchResult {
+            unimplemented!();
+        }
+
+        ////
+        //// 6. Refunding the contributed assets after auction success
+
+        /// If a `crowdloan` succeeded and its slot expired, use `call` to
+        /// claim back the funds lent to the parachain
+        #[pallet::weight(10_000)]
+        #[allow(unused)]
+        pub fn slot_expired(
+            origin: OriginFor<T>,
+            crowdloan: ParaId,
+            call: Box<u8>, // should be Box<Call> for use with sudo
+        ) -> DispatchResult {
+            ensure_root(origin)?;
+            unimplemented!();
+        }
+    }
+}

--- a/pallets/crowdloans/src/mock.rs
+++ b/pallets/crowdloans/src/mock.rs
@@ -1,0 +1,294 @@
+use crate as pallet_crowdloans;
+
+use codec::{Decode, Encode, MaxEncodedLen};
+use frame_benchmarking::frame_support::traits::tokens::{DepositConsequence, WithdrawConsequence};
+use frame_support::{
+    parameter_types,
+    traits::{
+        fungible::{
+            Inspect as FungibleInspect, Mutate as FungibleMutate, Transfer as FungibleTransfer,
+        },
+        fungibles::{Inspect, Mutate, Transfer},
+    },
+    PalletId,
+};
+use frame_system::{self as system, EnsureRoot};
+use primitives::{currency::CurrencyId, tokens, Balance};
+#[cfg(feature = "std")]
+use serde::{Deserialize, Serialize};
+use sp_core::H256;
+use sp_runtime::{
+    testing::Header,
+    traits::{BlakeTwo256, IdentityLookup},
+    DispatchError, DispatchResult, RuntimeDebug,
+};
+use std::marker::PhantomData;
+
+pub const ALICE: AccountId = AccountId(1);
+pub const BOB: AccountId = AccountId(2);
+pub const CHARLIE: AccountId = AccountId(3);
+pub const EVE: AccountId = AccountId(4);
+
+type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type Block = frame_system::mocking::MockBlock<Test>;
+type BlockNumber = u64;
+
+#[derive(
+    Encode,
+    Decode,
+    Default,
+    Eq,
+    PartialEq,
+    Copy,
+    Clone,
+    RuntimeDebug,
+    PartialOrd,
+    Ord,
+    MaxEncodedLen,
+)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize, Hash))]
+pub struct AccountId(pub u64);
+
+impl sp_std::fmt::Display for AccountId {
+    fn fmt(&self, f: &mut sp_std::fmt::Formatter<'_>) -> sp_std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl From<u64> for AccountId {
+    fn from(account_id: u64) -> Self {
+        Self(account_id)
+    }
+}
+
+// Configure a mock runtime to test the pallet.
+frame_support::construct_runtime!(
+    pub enum Test where
+        Block = Block,
+        NodeBlock = Block,
+        UncheckedExtrinsic = UncheckedExtrinsic,
+    {
+        System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
+        Balances: pallet_balances::{Pallet, Call, Storage, Event<T>},
+        Crowdloan: pallet_crowdloans::{Pallet, Call, Storage, Event<T>},
+        Assets: pallet_assets::{Pallet, Call, Storage, Event<T>},
+    }
+);
+
+parameter_types! {
+    pub const BlockHashCount: u64 = 250;
+    pub const SS58Prefix: u8 = 42;
+}
+
+impl system::Config for Test {
+    type BaseCallFilter = ();
+    type BlockWeights = ();
+    type BlockLength = ();
+    type DbWeight = ();
+    type Origin = Origin;
+    type Call = Call;
+    type Index = u64;
+    type BlockNumber = BlockNumber;
+    type Hash = H256;
+    type Hashing = BlakeTwo256;
+    type AccountId = AccountId;
+    type Lookup = IdentityLookup<Self::AccountId>;
+    type Header = Header;
+    type Event = Event;
+    type BlockHashCount = BlockHashCount;
+    type Version = ();
+    type PalletInfo = PalletInfo;
+    type AccountData = pallet_balances::AccountData<Balance>;
+    type OnNewAccount = ();
+    type OnKilledAccount = ();
+    type SystemWeightInfo = ();
+    type SS58Prefix = SS58Prefix;
+    type OnSetCode = ();
+}
+
+parameter_types! {
+    pub const ExistentialDeposit: Balance = 1;
+    pub const MaxLocks: u32 = 50;
+}
+
+impl pallet_balances::Config for Test {
+    type MaxLocks = MaxLocks;
+    type Balance = Balance;
+    type Event = Event;
+    type DustRemoval = ();
+    type MaxReserves = ();
+    type ReserveIdentifier = [u8; 8];
+    type ExistentialDeposit = ExistentialDeposit;
+    type AccountStore = System;
+    type WeightInfo = ();
+}
+
+parameter_types! {
+    pub const AssetDeposit: u64 = 1;
+    pub const ApprovalDeposit: u64 = 1;
+    pub const StringLimit: u32 = 50;
+    pub const MetadataDepositBase: u64 = 1;
+    pub const MetadataDepositPerByte: u64 = 1;
+}
+
+impl pallet_assets::Config for Test {
+    type Event = Event;
+    type Balance = u128;
+    type AssetId = u32;
+    type Currency = Balances;
+    type ForceOrigin = EnsureRoot<AccountId>;
+    type AssetDeposit = AssetDeposit;
+    type MetadataDepositBase = MetadataDepositBase;
+    type MetadataDepositPerByte = MetadataDepositPerByte;
+    type ApprovalDeposit = ApprovalDeposit;
+    type StringLimit = StringLimit;
+    type Freezer = ();
+    type Extra = ();
+    type WeightInfo = ();
+}
+
+parameter_types! {
+    pub const CrowdloanPalletId: PalletId = PalletId(*b"par/cwlp");
+}
+
+pub struct Adapter<AccountId> {
+    phantom: PhantomData<AccountId>,
+}
+
+impl Inspect<AccountId> for Adapter<AccountId> {
+    type AssetId = CurrencyId;
+    type Balance = Balance;
+
+    fn total_issuance(asset: Self::AssetId) -> Self::Balance {
+        match asset {
+            CurrencyId::Native => Balances::total_issuance(),
+            CurrencyId::Asset(asset_id) => Assets::total_issuance(asset_id),
+        }
+    }
+
+    fn balance(asset: Self::AssetId, who: &AccountId) -> Self::Balance {
+        match asset {
+            CurrencyId::Native => Balances::balance(who),
+            CurrencyId::Asset(asset_id) => Assets::balance(asset_id, who),
+        }
+    }
+
+    fn minimum_balance(asset: Self::AssetId) -> Self::Balance {
+        match asset {
+            CurrencyId::Native => Balances::minimum_balance(),
+            CurrencyId::Asset(asset_id) => Assets::minimum_balance(asset_id),
+        }
+    }
+
+    fn reducible_balance(asset: Self::AssetId, who: &AccountId, keep_alive: bool) -> Self::Balance {
+        match asset {
+            CurrencyId::Native => Balances::reducible_balance(who, keep_alive),
+            CurrencyId::Asset(asset_id) => Assets::reducible_balance(asset_id, who, keep_alive),
+        }
+    }
+
+    fn can_deposit(
+        asset: Self::AssetId,
+        who: &AccountId,
+        amount: Self::Balance,
+    ) -> DepositConsequence {
+        match asset {
+            CurrencyId::Native => Balances::can_deposit(who, amount),
+            CurrencyId::Asset(asset_id) => Assets::can_deposit(asset_id, who, amount),
+        }
+    }
+
+    fn can_withdraw(
+        asset: Self::AssetId,
+        who: &AccountId,
+        amount: Self::Balance,
+    ) -> WithdrawConsequence<Self::Balance> {
+        match asset {
+            CurrencyId::Native => Balances::can_withdraw(who, amount),
+            CurrencyId::Asset(asset_id) => Assets::can_withdraw(asset_id, who, amount),
+        }
+    }
+}
+
+impl Mutate<AccountId> for Adapter<AccountId> {
+    fn mint_into(asset: Self::AssetId, who: &AccountId, amount: Self::Balance) -> DispatchResult {
+        match asset {
+            CurrencyId::Native => Balances::mint_into(who, amount),
+            CurrencyId::Asset(asset_id) => Assets::mint_into(asset_id, who, amount),
+        }
+    }
+
+    fn burn_from(
+        asset: Self::AssetId,
+        who: &AccountId,
+        amount: Balance,
+    ) -> Result<Balance, DispatchError> {
+        match asset {
+            CurrencyId::Native => Balances::burn_from(who, amount),
+            CurrencyId::Asset(asset_id) => Assets::burn_from(asset_id, who, amount),
+        }
+    }
+}
+
+impl Transfer<AccountId> for Adapter<AccountId>
+where
+    Assets: Transfer<AccountId>,
+{
+    fn transfer(
+        asset: Self::AssetId,
+        source: &AccountId,
+        dest: &AccountId,
+        amount: Self::Balance,
+        keep_alive: bool,
+    ) -> Result<Balance, DispatchError> {
+        match asset {
+            CurrencyId::Native => <Balances as FungibleTransfer<AccountId>>::transfer(
+                source, dest, amount, keep_alive,
+            ),
+            CurrencyId::Asset(asset_id) => <Assets as Transfer<AccountId>>::transfer(
+                asset_id, source, dest, amount, keep_alive,
+            ),
+        }
+    }
+}
+
+impl pallet_crowdloans::Config for Test {
+    type Event = Event;
+    type PalletId = CrowdloanPalletId;
+    type CrowdloanCurrency = Adapter<AccountId>;
+}
+
+// Build genesis storage according to the mock runtime.
+pub fn new_test_ext() -> sp_io::TestExternalities {
+    let mut t = system::GenesisConfig::default()
+        .build_storage::<Test>()
+        .unwrap();
+    pallet_balances::GenesisConfig::<Test> {
+        balances: vec![
+            (ALICE, 100_000_000),
+            (BOB, 100_000_000),
+            (CHARLIE, 1000_000_000),
+            (EVE, 1000_000_000),
+        ],
+    }
+    .assimilate_storage(&mut t)
+    .unwrap();
+
+    let mut ext = sp_io::TestExternalities::new(t);
+    ext.execute_with(|| {
+        Assets::force_create(Origin::root(), tokens::DOT, ALICE, true, 1).unwrap();
+        Assets::force_create(Origin::root(), tokens::XDOT, ALICE, true, 1).unwrap();
+
+        Assets::mint(Origin::signed(ALICE), tokens::DOT, ALICE, 100_000_000).unwrap();
+        Assets::mint(Origin::signed(ALICE), tokens::DOT, BOB, 100_000_000).unwrap();
+        Assets::mint(Origin::signed(ALICE), tokens::DOT, CHARLIE, 1000_000_000).unwrap();
+        Assets::mint(Origin::signed(ALICE), tokens::DOT, EVE, 1000_000_000).unwrap();
+
+        Assets::mint(Origin::signed(ALICE), tokens::XDOT, ALICE, 100_000_000).unwrap();
+        Assets::mint(Origin::signed(ALICE), tokens::XDOT, BOB, 100_000_000).unwrap();
+        Assets::mint(Origin::signed(ALICE), tokens::XDOT, CHARLIE, 1000_000_000).unwrap();
+        Assets::mint(Origin::signed(ALICE), tokens::XDOT, EVE, 1000_000_000).unwrap();
+    });
+
+    ext
+}

--- a/pallets/crowdloans/src/tests.rs
+++ b/pallets/crowdloans/src/tests.rs
@@ -1,0 +1,32 @@
+use super::*;
+use crate::mock::*;
+use frame_support::assert_ok;
+
+#[test]
+fn create_new_vault_should_work() {
+    new_test_ext().execute_with(|| {
+        let vault_id = 0;
+
+        assert_ok!(Crowdloan::create_vault(
+            frame_system::RawOrigin::Root.into(), // origin
+            CurrencyId::Asset(1),                 // token
+            vault_id,                             // crowdloan
+            0,                                    // project_shares
+            1,                                    // currency_shares
+            9_999_999,                            // until
+        ));
+
+        if let Some(just_created_vault) = Crowdloan::vaults(vault_id) {
+            assert_eq!(
+                just_created_vault,
+                Vault {
+                    project_shares: 0,
+                    currency_shares: 1,
+                    currency: CurrencyId::Asset(1),
+                    phase: VaultPhase::CollectingContributionsUntil(9_999_999),
+                    claimed: 0
+                }
+            );
+        }
+    });
+}


### PR DESCRIPTION
This draft PR converts https://www.notion.so/parallelfinance/pallet-crowdloans-a6a966a02e8347c793a154c7f64903b1 blueprint into a pallet we can test. 

Most functions are `unimplemented!();` and I was confused by `Box<Call>` so those args have been replaced by `Box<u8>` in order to successfully compile and test with `cargo test -p pallet-crowdloans`

This PR aims to implement most of the scaffolding we'll need for the pallet going forwards and is likely to change as we refine the spec.