### PR TITLE
Disable direct XCM execution

### DIFF
--- a/runtime/heiko/src/lib.rs
+++ b/runtime/heiko/src/lib.rs
@@ -130,7 +130,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("heiko"),
     impl_name: create_runtime_str!("heiko"),
     authoring_version: 1,
-    spec_version: 170,
+    spec_version: 171,
     impl_version: 20,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 2,

--- a/runtime/parallel/src/lib.rs
+++ b/runtime/parallel/src/lib.rs
@@ -129,7 +129,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("parallel"),
     impl_name: create_runtime_str!("parallel"),
     authoring_version: 1,
-    spec_version: 170,
+    spec_version: 171,
     impl_version: 20,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 2,

--- a/runtime/vanilla/src/lib.rs
+++ b/runtime/vanilla/src/lib.rs
@@ -128,7 +128,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("vanilla"),
     impl_name: create_runtime_str!("vanilla"),
     authoring_version: 1,
-    spec_version: 170,
+    spec_version: 171,
     impl_version: 20,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 2,


### PR DESCRIPTION
This pull request disable the direct execution of XCM messages. Karura recently ran into issues because of this same configuration mistake: https://medium.com/kusama-network/kusamas-governance-thwarts-would-be-attacker-9023180f6fb