### PR TITLE
ED-33: integrate chainlink oracle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5237,6 +5237,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-chainlink-adapter"
+version = "1.7.5"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "orml-oracle",
+ "orml-traits",
+ "pallet-chainlink-feed",
+ "parallel-primitives",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-chainlink-feed"
+version = "0.1.0"
+source = "git+https://github.com/smartcontractkit/chainlink-polkadot?branch=polkadot-v0.9.12#8ad333a2c04030f69736e5fb4651ce1ca4249a60"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
 name = "pallet-collator-selection"
 version = "3.0.0"
 source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.12#935bac869a72baef17e46d2ae1abc8c0c650cef5"
@@ -11415,6 +11448,8 @@ dependencies = [
  "pallet-authorship",
  "pallet-balances",
  "pallet-bridge",
+ "pallet-chainlink-adapter",
+ "pallet-chainlink-feed",
  "pallet-collator-selection",
  "pallet-collective",
  "pallet-crowdloans",

--- a/pallets/chainlink-adapter/Cargo.toml
+++ b/pallets/chainlink-adapter/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+authors = ['Parallel Team']
+edition = '2018'
+name    = 'pallet-chainlink-adapter'
+version = '1.7.5'
+
+[package.metadata.docs.rs]
+targets = ['x86_64-unknown-linux-gnu']
+
+[dependencies]
+codec                        = { package = 'parity-scale-codec', version = '2.3.1', features = ['max-encoded-len'], default-features = false }
+frame-support                = { git = 'https://github.com/paritytech/substrate.git', branch = 'polkadot-v0.9.12', default-features = false }
+frame-system                 = { git = 'https://github.com/paritytech/substrate.git', branch = 'polkadot-v0.9.12', default-features = false }
+primitives                   = { package = 'parallel-primitives', path = '../../primitives', default-features = false }
+scale-info                   = { version = '1.0', default-features = false, features = ['derive'] }
+sp-runtime                   = { git = 'https://github.com/paritytech/substrate.git', branch = 'polkadot-v0.9.12', default-features = false }
+sp-std                       = { git = 'https://github.com/paritytech/substrate.git', branch = 'polkadot-v0.9.12', default-features = false }
+pallet-chainlink-feed        = { git = "https://github.com/smartcontractkit/chainlink-polkadot", branch = "polkadot-v0.9.12", default-features = false }
+orml-oracle                  = { git = 'https://github.com/open-web3-stack/open-runtime-module-library.git', default-features = false }
+orml-traits                  = { git = 'https://github.com/open-web3-stack/open-runtime-module-library.git', default-features = false }
+[features]
+default     = ['std']
+std         = [
+  'codec/std',
+  'frame-support/std',
+  'frame-system/std',
+  'sp-runtime/std',
+  'sp-std/std',
+  'scale-info/std',
+  'primitives/std',
+  'pallet-chainlink-feed/std',
+  'orml-traits/std',
+  'orml-oracle/std',
+]
+try-runtime = ['frame-support/try-runtime']
+
+[lib]
+doctest = false

--- a/pallets/chainlink-adapter/src/lib.rs
+++ b/pallets/chainlink-adapter/src/lib.rs
@@ -1,0 +1,158 @@
+// Copyright 2021 Parallel Finance Developer.
+// This file is part of Parallel Finance.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! # Chainlink adapter pallet
+//!
+//! ## Overview
+//!
+//! This pallet works with chainlink pallet
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use frame_support::{
+    pallet_prelude::*,
+    dispatch::DispatchResult,
+    traits::{
+        tokens::{
+            fungible::{Inspect, Mutate, Transfer},
+            fungibles::{Inspect as Inspects, Mutate as Mutates, Transfer as Transfers},
+            DepositConsequence, WithdrawConsequence,
+        },
+        Get, Time,
+    },
+};
+use orml_oracle::DataProviderExtended;
+use orml_traits::DataProvider;
+use pallet_chainlink_feed::{traits::OnAnswerHandler, FeedInterface, FeedOracle,RoundData};
+use primitives::*;
+use sp_runtime::DispatchError;
+use sp_runtime::traits::Convert;
+use frame_system::pallet_prelude::*;
+pub type FeedIdFor<T> = <T as pallet_chainlink_feed::Config>::FeedId;
+pub type FeedValueFor<T> = <T as pallet_chainlink_feed::Config>::Value;
+pub type MomentOf<T> = <<T as Config>::Time as Time>::Moment;
+use sp_std::vec::Vec;
+pub use pallet::*;
+
+#[frame_support::pallet]
+pub mod pallet {
+    use super::*;
+
+    #[pallet::config]
+    pub trait Config: frame_system::Config + pallet_chainlink_feed::Config {
+        type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
+        /// Convert feed_value type of chainlink to price type
+        type Convert: Convert<FeedValueFor<Self>, Option<Price>>;
+        /// Type to keep track of timestamped values
+        type Time: Time;
+        /// The origin which can map a `FeedId` of chainlink oracle to `CurrencyId`.
+        type FeedMapOrigin: EnsureOrigin<Self::Origin>;
+    }
+
+    #[pallet::event]
+	#[pallet::generate_deposit(pub(crate) fn deposit_event)]
+	pub enum Event<T: Config> {
+		/// Map feed_id to currency_id. \[feed_id, currency_id\]
+		MapFeedId(FeedIdFor<T>, CurrencyId),
+	}
+
+    /// Stores the timestamp of the latest answer of each feed
+    /// (feed) -> Timestamp
+    #[pallet::storage]
+    #[pallet::getter(fn latest_answer_timestamp)]
+    pub type LatestAnswerTimestamp<T: Config> =
+        StorageMap<_, Twox64Concat, FeedIdFor<T>, MomentOf<T>, ValueQuery>;
+
+    /// Mapping from currency_id to feed_id
+    ///
+    /// FeedIdMapping: CurrencyId => FeedId
+    #[pallet::storage]
+    #[pallet::getter(fn feed_id_mapping)]
+    pub type FeedIdMapping<T: Config> =
+        StorageMap<_, Twox64Concat, CurrencyId, FeedIdFor<T>, OptionQuery>;
+
+    #[pallet::pallet]
+    pub struct Pallet<T>(PhantomData<T>);
+
+    #[pallet::call]
+    impl<T: Config> Pallet<T> {
+        /// Maps the given currency id to an existing chainlink feed.
+        ///
+        /// The dispatch origin of this call must be `FeedMapOrigin`.
+        ///
+        /// - `currency_id`: currency_id.
+        /// - `feed_id`: feed_id in chainlink oracle.
+        #[pallet::weight(10_000)]
+        pub fn map_feed_id(
+            origin: OriginFor<T>,
+            currency_id: CurrencyId,
+            feed_id: FeedIdFor<T>,
+        ) -> DispatchResult {
+            T::FeedMapOrigin::ensure_origin(origin)?;
+            // if already mapped, update
+            let old_feed_id = FeedIdMapping::<T>::mutate(&currency_id, |maybe_feed_id| {
+                maybe_feed_id.replace(feed_id)
+            });
+            Self::deposit_event(Event::MapFeedId(feed_id, currency_id));
+            Ok(())
+        }
+    }
+}
+
+impl<T: Config> Pallet<T> {
+    fn get_price_from_chainlink_feed(currency_id: &CurrencyId) -> Option<Price> {
+        Self::feed_id_mapping(currency_id)
+            .and_then(<pallet_chainlink_feed::Pallet<T>>::feed)
+            .map(|feed| feed.latest_data().answer)
+            .and_then(T::Convert::convert)
+    }
+}
+
+// Implement the `OnAnswerHandler` that gets called by the `chainlink pallet` on every new answer
+impl<T: Config> OnAnswerHandler<T> for Pallet<T> {
+    fn on_answer(feed_id: FeedIdFor<T>, _: RoundData<T::BlockNumber, FeedValueFor<T>>) {
+        // keep track of the timestamp
+        LatestAnswerTimestamp::<T>::insert(feed_id, T::Time::now());
+    }
+}
+
+impl<T: Config> DataProvider<CurrencyId, Price> for Pallet<T> {
+    fn get(key: &CurrencyId) -> Option<Price> {
+        Self::get_price_from_chainlink_feed(key)
+    }
+}
+
+impl<T: Config> DataProviderExtended<CurrencyId, TimeStampedPrice> for Pallet<T> 
+where u64: From<<<T as pallet::Config>::Time as frame_support::traits::Time>::Moment>
+{
+    fn get_no_op(key: &CurrencyId) -> Option<TimeStampedPrice> {
+        Self::get_price_from_chainlink_feed(key).map(|price| TimeStampedPrice {
+            value: price,
+            timestamp: Self::feed_id_mapping(key)
+                .map(Self::latest_answer_timestamp)
+                .map(sp_std::convert::TryFrom::try_from)
+                .and_then(sp_std::result::Result::ok)
+                .unwrap_or_default(),
+        })
+    }
+
+    fn get_all_values() -> Vec<(CurrencyId, Option<TimeStampedPrice>)> {
+        FeedIdMapping::<T>::iter()
+            .map(|(currency_id, _)| {
+                let maybe_price = Self::get_no_op(&currency_id);
+                (currency_id, maybe_price)
+            })
+            .collect()
+    }
+}

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -80,6 +80,8 @@ pub type Timestamp = u64;
 
 pub type CurrencyId = u32;
 
+pub type FeedId = u32;
+
 pub type ChainId = u8;
 
 pub const SECONDS_PER_YEAR: Timestamp = 365 * 24 * 60 * 60;

--- a/runtime/vanilla/Cargo.toml
+++ b/runtime/vanilla/Cargo.toml
@@ -102,6 +102,8 @@ pallet-prices                = { path = '../../pallets/prices', default-features
 pallet-router                = { path = '../../pallets/router', default-features = false }
 pallet-xcm-helper            = { path = '../../pallets/xcm-helper', default-features = false }
 primitives                   = { package = 'parallel-primitives', path = '../../primitives', default-features = false }
+pallet-chainlink-adapter     = { path = '../../pallets/chainlink-adapter', default-features = false }
+pallet-chainlink-feed        = { git = "https://github.com/smartcontractkit/chainlink-polkadot", branch = "polkadot-v0.9.12", default-features = false }
 
 [build-dependencies.substrate-wasm-builder]
 branch = 'polkadot-v0.9.12'
@@ -209,6 +211,8 @@ std                = [
   'pallet-crowdloans/std',
   'pallet-emergency-shutdown/std',
   'pallet-xcm-helper/std',
+  'pallet-chainlink-adapter/std',
+  'pallet-chainlink-feed/std',
 ]
 try-runtime        = [
   'frame-support/try-runtime',
@@ -243,4 +247,5 @@ try-runtime        = [
   'pallet-prices/try-runtime',
   'pallet-crowdloans/try-runtime',
   'pallet-xcm-helper/try-runtime',
+  'pallet-chainlink-adapter/try-runtime',
 ]

--- a/runtime/vanilla/src/lib.rs
+++ b/runtime/vanilla/src/lib.rs
@@ -1500,7 +1500,9 @@ impl Contains<Call> for WhiteListFilter {
             Call::TechnicalCommitteeMembership(_) |
             Call::OracleMembership(_) |
             Call::BridgeMembership(_) |
-            Call::ValidatorFeedersMembership(_)
+            Call::ValidatorFeedersMembership(_) |
+            Call::ChainlinkFeed(_) |
+            Call::ChainlinkAdaptor(_)
         )
         // // AMM
         // Call::AMM(_) |

--- a/runtime/vanilla/src/lib.rs
+++ b/runtime/vanilla/src/lib.rs
@@ -272,7 +272,7 @@ impl Contains<Call> for CallFilterRouter {
 
 impl frame_system::Config for Runtime {
     /// The basic call filter to use in dispatchable.
-    type BaseCallFilter = CallFilterRouter;
+    type BaseCallFilter = Everything;
     /// Block & extrinsics weights: base values and limits.
     type BlockWeights = RuntimeBlockWeights;
     /// The maximum length of a block (in bytes).

--- a/runtime/vanilla/src/lib.rs
+++ b/runtime/vanilla/src/lib.rs
@@ -1019,17 +1019,17 @@ pub type TimeStampedPrice = orml_oracle::TimestampedValue<Price, Moment>;
 pub struct AggregatedDataProvider;
 impl DataProvider<CurrencyId, TimeStampedPrice> for AggregatedDataProvider {
     fn get(key: &CurrencyId) -> Option<TimeStampedPrice> {
-        Oracle::get(key)
+        ChainlinkAdaptor::get_no_op(key)
     }
 }
 
 impl DataProviderExtended<CurrencyId, TimeStampedPrice> for AggregatedDataProvider {
     fn get_no_op(key: &CurrencyId) -> Option<TimeStampedPrice> {
-        Oracle::get_no_op(key)
+        ChainlinkAdaptor::get_no_op(key)
     }
 
     fn get_all_values() -> Vec<(CurrencyId, Option<TimeStampedPrice>)> {
-        Oracle::get_all_values()
+        ChainlinkAdaptor::get_all_values()
     }
 }
 

--- a/runtime/vanilla/src/lib.rs
+++ b/runtime/vanilla/src/lib.rs
@@ -256,7 +256,9 @@ impl Contains<Call> for BaseCallFilter {
             // Bridge
             Call::Bridge(_) |
             // Liquidity Mining
-            Call::LiquidityMining(_)
+            Call::LiquidityMining(_) |
+            Call::ChainlinkFeed(_) |
+            Call::ChainlinkAdaptor(_)
         )
     }
 }


### PR DESCRIPTION
close #824 

- [ ]  can not use **LINK** through the current `CurrencyAdapter` pallet, however, this is what the `chainlink-feed` pallet needs
- [ ] combine `orml-oracle` and `chainlink-adapter` in runtime