### PR TITLE
Pallet crowdloans xcm simulator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5306,6 +5306,7 @@ dependencies = [
  "parity-scale-codec",
  "polkadot-core-primitives",
  "polkadot-parachain",
+ "polkadot-runtime-common",
  "polkadot-runtime-parachains",
  "scale-info",
  "serde",

--- a/pallets/crowdloans/Cargo.toml
+++ b/pallets/crowdloans/Cargo.toml
@@ -38,6 +38,7 @@ parachain-info                  = { git = 'https://github.com/paritytech/cumulus
 polkadot-core-primitives        = { git = 'https://github.com/paritytech/polkadot.git', branch = 'release-v0.9.13' }
 polkadot-parachain              = { git = 'https://github.com/paritytech/polkadot.git', branch = 'release-v0.9.13' }
 polkadot-runtime-parachains     = { git = 'https://github.com/paritytech/polkadot.git', branch = 'release-v0.9.13' }
+polkadot-runtime-common         = { git = 'https://github.com/paritytech/polkadot.git', branch = 'release-v0.9.13' }
 serde                           = { version = '1' }
 sp-core                         = { git = 'https://github.com/paritytech/substrate.git', branch = 'polkadot-v0.9.13' }
 sp-io                           = { git = 'https://github.com/paritytech/substrate.git', branch = 'polkadot-v0.9.13' }

--- a/pallets/crowdloans/src/mock.rs
+++ b/pallets/crowdloans/src/mock.rs
@@ -9,7 +9,7 @@ use frame_support::{
 use frame_system::{EnsureOneOf, EnsureRoot, EnsureSignedBy};
 use orml_xcm_support::IsNativeConcrete;
 use pallet_xcm::XcmPassthrough;
-use polkadot_parachain::primitives::Sibling;
+use polkadot_parachain::primitives::{HeadData, Sibling, ValidationCode};
 use primitives::{currency::MultiCurrencyAdapter, tokens::*, Balance, ParaId};
 use sp_core::H256;
 use sp_runtime::{
@@ -140,10 +140,21 @@ impl Config for XcmConfig {
     type AssetClaims = PolkadotXcm;
 }
 
+type KusamaXcmOriginToCallOrigin = (
+    // A `Signed` origin of the sovereign account that the original location controls.
+    SovereignSignedViaLocation<kusama_runtime::SovereignAccountOf, kusama_runtime::Origin>,
+    // A child parachain, natively expressed, has the `Parachain` origin.
+    ChildParachainAsNative<polkadot_runtime_parachains::origin::Origin, kusama_runtime::Origin>,
+    // The AccountId32 location type can be expressed natively as a `Signed` origin.
+    SignedAccountId32AsNative<kusama_runtime::KusamaNetwork, kusama_runtime::Origin>,
+    // A system child parachain, expressed as a Superuser, converts to the `Root` origin.
+    ChildSystemParachainAsSuperuser<ParaId, kusama_runtime::Origin>,
+);
+
 pub type KusamaCall = kusama_runtime::Call;
 pub type KusamaLocalAssetTransactor = kusama_runtime::LocalAssetTransactor;
-pub type KusamaXcmOriginToCallOrigin = kusama_runtime::LocalOriginConverter;
-pub type KusamaLocationInverter = kusama_runtime::LocationInverter;
+// pub type KusamaXcmOriginToCallOrigin = kusama_runtime::LocalOriginConverter;
+// pub type KusamaLocationInverter = kusama_runtime::LocationInverter;
 pub type KusamaAncestry = kusama_runtime::Ancestry;
 pub type KusamaBarrier = kusama_runtime::Barrier;
 pub type KusamaXcmPallet = kusama_runtime::XcmPallet;
@@ -156,7 +167,7 @@ impl Config for RelayXcmConfig {
     type OriginConverter = KusamaXcmOriginToCallOrigin;
     type IsReserve = ();
     type IsTeleporter = ();
-    type LocationInverter = KusamaLocationInverter<KusamaAncestry>;
+    type LocationInverter = LocationInverter<KusamaAncestry>;
     type Barrier = KusamaBarrier;
     type Weigher = FixedWeightBounds<UnitWeightCost, KusamaCall, MaxInstructions>;
     type Trader = FixedRateOfFungible<DotPerSecond, ()>;
@@ -520,12 +531,21 @@ decl_test_network! {
 }
 
 pub type KusamaRuntime = kusama_runtime::Runtime;
+pub type RelayRegistrar = polkadot_runtime_common::paras_registrar::Pallet<KusamaRuntime>;
+pub type RelayParas = polkadot_runtime_parachains::paras::Pallet<KusamaRuntime>;
+pub type RelayCrowdloan = polkadot_runtime_common::crowdloan::Pallet<KusamaRuntime>;
+pub type RelayInitializer = polkadot_runtime_parachains::initializer::Pallet<KusamaRuntime>;
 pub type RelayCrowdloanEvent = polkadot_runtime_common::crowdloan::Event<KusamaRuntime>;
 pub type RelaySystem = frame_system::Pallet<KusamaRuntime>;
+pub type RelaySession = pallet_session::Pallet<KusamaRuntime>;
 pub type RelayEvent = kusama_runtime::Event;
 
 pub fn para_a_id() -> ParaId {
     ParaId::from(1)
+}
+
+pub fn parathread_id() -> ParaId {
+    ParaId::from(2001)
 }
 
 pub fn para_ext(para_id: u32) -> sp_io::TestExternalities {
@@ -547,7 +567,7 @@ pub fn para_ext(para_id: u32) -> sp_io::TestExternalities {
         System::set_block_number(1);
         Assets::force_create(Origin::root(), DOT, Id(ALICE), true, 1).unwrap();
         Assets::force_create(Origin::root(), XDOT, Id(ALICE), true, 1).unwrap();
-        Assets::mint(Origin::signed(ALICE), DOT, Id(ALICE), 100 * DOT_DECIMAL).unwrap();
+        Assets::mint(Origin::signed(ALICE), DOT, Id(ALICE), 100_000 * DOT_DECIMAL).unwrap();
         Assets::mint(Origin::signed(ALICE), XDOT, Id(ALICE), 100 * DOT_DECIMAL).unwrap();
         Assets::mint(
             Origin::signed(ALICE),
@@ -570,7 +590,7 @@ pub fn relay_ext() -> sp_io::TestExternalities {
 
     pallet_balances::GenesisConfig::<Runtime> {
         balances: vec![
-            (ALICE, 100 * DOT_DECIMAL),
+            (ALICE, 100_000 * DOT_DECIMAL),
             (para_a_id().into_account(), 1_000_000 * DOT_DECIMAL),
         ],
     }

--- a/pallets/crowdloans/src/mock.rs
+++ b/pallets/crowdloans/src/mock.rs
@@ -140,6 +140,32 @@ impl Config for XcmConfig {
     type AssetClaims = PolkadotXcm;
 }
 
+pub type KusamaCall = kusama_runtime::Call;
+pub type KusamaLocalAssetTransactor = kusama_runtime::LocalAssetTransactor;
+pub type KusamaXcmOriginToCallOrigin = kusama_runtime::LocalOriginConverter;
+pub type KusamaLocationInverter = kusama_runtime::LocationInverter;
+pub type KusamaAncestry = kusama_runtime::Ancestry;
+pub type KusamaBarrier = kusama_runtime::Barrier;
+pub type KusamaXcmPallet = kusama_runtime::XcmPallet;
+
+pub struct RelayXcmConfig;
+impl Config for RelayXcmConfig {
+    type Call = KusamaCall;
+    type XcmSender = RelayChainXcmRouter;
+    type AssetTransactor = KusamaLocalAssetTransactor;
+    type OriginConverter = KusamaXcmOriginToCallOrigin;
+    type IsReserve = ();
+    type IsTeleporter = ();
+    type LocationInverter = KusamaLocationInverter<KusamaAncestry>;
+    type Barrier = KusamaBarrier;
+    type Weigher = FixedWeightBounds<UnitWeightCost, KusamaCall, MaxInstructions>;
+    type Trader = FixedRateOfFungible<DotPerSecond, ()>;
+    type ResponseHandler = KusamaXcmPallet;
+    type SubscriptionService = KusamaXcmPallet;
+    type AssetTrap = KusamaXcmPallet;
+    type AssetClaims = KusamaXcmPallet;
+}
+
 impl cumulus_pallet_xcmp_queue::Config for Test {
     type Event = Event;
     type XcmExecutor = XcmExecutor<XcmConfig>;
@@ -479,7 +505,7 @@ decl_test_parachain! {
 decl_test_relay_chain! {
     pub struct Relay {
         Runtime = kusama_runtime::Runtime,
-        XcmConfig = kusama_runtime::XcmConfig,
+        XcmConfig = RelayXcmConfig,
         new_ext = relay_ext(),
     }
 }
@@ -492,6 +518,11 @@ decl_test_network! {
         ],
     }
 }
+
+pub type KusamaRuntime = kusama_runtime::Runtime;
+pub type RelayCrowdloanEvent = polkadot_runtime_common::crowdloan::Event<KusamaRuntime>;
+pub type RelaySystem = frame_system::Pallet<KusamaRuntime>;
+pub type RelayEvent = kusama_runtime::Event;
 
 pub fn para_a_id() -> ParaId {
     ParaId::from(1)

--- a/pallets/crowdloans/src/mock.rs
+++ b/pallets/crowdloans/src/mock.rs
@@ -9,7 +9,7 @@ use frame_support::{
 use frame_system::{EnsureOneOf, EnsureRoot, EnsureSignedBy};
 use orml_xcm_support::IsNativeConcrete;
 use pallet_xcm::XcmPassthrough;
-use polkadot_parachain::primitives::{HeadData, Sibling, ValidationCode};
+use polkadot_parachain::primitives::Sibling;
 use primitives::{currency::MultiCurrencyAdapter, tokens::*, Balance, ParaId};
 use sp_core::H256;
 use sp_runtime::{
@@ -537,7 +537,6 @@ pub type RelayCrowdloan = polkadot_runtime_common::crowdloan::Pallet<KusamaRunti
 pub type RelayInitializer = polkadot_runtime_parachains::initializer::Pallet<KusamaRuntime>;
 pub type RelayCrowdloanEvent = polkadot_runtime_common::crowdloan::Event<KusamaRuntime>;
 pub type RelaySystem = frame_system::Pallet<KusamaRuntime>;
-pub type RelaySession = pallet_session::Pallet<KusamaRuntime>;
 pub type RelayEvent = kusama_runtime::Event;
 
 pub fn para_a_id() -> ParaId {

--- a/pallets/crowdloans/src/tests.rs
+++ b/pallets/crowdloans/src/tests.rs
@@ -708,7 +708,7 @@ fn xcm_contribute_should_work() {
 
         // check that we're in the right phase
         let vault = Crowdloans::vaults(crowdloan, VAULT_ID).unwrap();
-        assert_eq!(vault.phase, VaultPhase::Contributing);  
+        assert_eq!(vault.phase, VaultPhase::Contributing);
     });
     Relay::execute_with(|| {
         RelaySystem::assert_has_event(RelayEvent::Crowdloan(RelayCrowdloanEvent::Contributed(
@@ -718,6 +718,3 @@ fn xcm_contribute_should_work() {
         )));
     });
 }
-
-#[test]
-fn xcm_withdraw_should_work() {}

--- a/pallets/crowdloans/src/tests.rs
+++ b/pallets/crowdloans/src/tests.rs
@@ -6,7 +6,7 @@ use frame_support::{
     traits::{Hooks, OneSessionHandler},
 };
 use frame_system::RawOrigin;
-use polkadot_parachain::primitives::{HeadData, Sibling, ValidationCode};
+use polkadot_parachain::primitives::{HeadData, ValidationCode};
 use primitives::{BlockNumber, ParaId};
 use sp_runtime::{
     traits::{One, UniqueSaturatedInto, Zero},
@@ -661,15 +661,6 @@ fn xcm_contribute_should_work() {
             10000,
             None
         ));
-        assert_ok!(RelayCrowdloan::edit(
-            RawOrigin::Root.into(),
-            crowdloan,
-            cap,
-            0,
-            7,
-            10000,
-            None
-        ));
     });
 
     ParaA::execute_with(|| {
@@ -716,5 +707,10 @@ fn xcm_contribute_should_work() {
             crowdloan,
             amount,
         )));
+        // println!("relay: {:?}", RelaySystem::events());
     });
+
+    // ParaA::execute_with(|| {
+    //     println!("para: {:?}", System::events());
+    // });
 }


### PR DESCRIPTION
close #1096 
Xcm `ReportError` can not test in xcm simulator because it needs to be processed at another block.
In simulator, it seems like parachain side will receive dmp message however can not process it.

Would like to merge this PR because it shows how to use xcmconfig on relaychain side, may refer it future.

![xcm](https://user-images.githubusercontent.com/26266313/147914044-d19b38ff-0d5c-467e-9c2e-42046bedffe9.jpg)
