### PR TITLE
expose chain state for emergency shutdown pallet

### DIFF
--- a/runtime/heiko/src/lib.rs
+++ b/runtime/heiko/src/lib.rs
@@ -1552,7 +1552,7 @@ construct_runtime!(
 
         // Others
         // Bridge: pallet_bridge::{Pallet, Call, Storage, Event<T>} = 90,
-        EmergencyShutdown: pallet_emergency_shutdown::{Pallet, Call, Event<T>} = 91,
+        EmergencyShutdown: pallet_emergency_shutdown::{Pallet, Call, Storage, Event<T>} = 91,
         // LiquidityMining: pallet_liquidity_mining::{Pallet, Call, Storage, Event<T>} = 92,
         XcmHelper: pallet_xcm_helper::{Pallet, Call, Storage, Event<T>} = 93,
     }

--- a/runtime/parallel/src/lib.rs
+++ b/runtime/parallel/src/lib.rs
@@ -1530,7 +1530,7 @@ construct_runtime!(
 
         // Others
         // Bridge: pallet_bridge::{Pallet, Call, Storage, Event<T>} = 90,
-        EmergencyShutdown: pallet_emergency_shutdown::{Pallet, Call, Event<T>} = 91,
+        EmergencyShutdown: pallet_emergency_shutdown::{Pallet, Call, Storage, Event<T>} = 91,
         // LiquidityMining: pallet_liquidity_mining::{Pallet, Call, Storage, Event<T>} = 92,
         XcmHelper: pallet_xcm_helper::{Pallet, Call, Storage, Event<T>} = 93,
     }

--- a/runtime/vanilla/src/lib.rs
+++ b/runtime/vanilla/src/lib.rs
@@ -1597,7 +1597,7 @@ construct_runtime!(
 
         // Others
         Bridge: pallet_bridge::{Pallet, Call, Storage, Event<T>} = 90,
-        EmergencyShutdown: pallet_emergency_shutdown::{Pallet, Call, Event<T>} = 91,
+        EmergencyShutdown: pallet_emergency_shutdown::{Pallet, Call, Storage, Event<T>} = 91,
         LiquidityMining: pallet_liquidity_mining::{Pallet, Call, Storage, Event<T>} = 92,
         XcmHelper: pallet_xcm_helper::{Pallet, Call, Storage, Event<T>} = 93,
     }


### PR DESCRIPTION
Previously the emergency shutdown chain state was not available due to the omission of the `Storage` item in the `construct_runtime` macro. This PR fixes that.
