### PR TITLE
add vec to benchmarking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ check:
 
 .PHONY: check-wasm
 check-wasm:
-	cargo check -p vanilla-runtime -p parallel-runtime -p heiko-runtime
+	cargo check -p vanilla-runtime -p parallel-runtime -p heiko-runtime --features runtime-benchmarks
 
 .PHONY: test
 test:

--- a/pallets/router/src/benchmarking.rs
+++ b/pallets/router/src/benchmarking.rs
@@ -22,6 +22,7 @@ use frame_support::{
 use frame_system::{self, RawOrigin as SystemOrigin};
 use primitives::{tokens, Balance, CurrencyId};
 use sp_runtime::traits::{One, StaticLookup};
+use sp_std::vec::Vec;
 
 const DOT: CurrencyId = tokens::DOT;
 const XDOT: CurrencyId = tokens::XDOT;

--- a/pallets/router/src/benchmarking.rs
+++ b/pallets/router/src/benchmarking.rs
@@ -22,7 +22,7 @@ use frame_support::{
 use frame_system::{self, RawOrigin as SystemOrigin};
 use primitives::{tokens, Balance, CurrencyId};
 use sp_runtime::traits::{One, StaticLookup};
-use sp_std::vec::Vec;
+use sp_std::{vec, vec::Vec};
 
 const DOT: CurrencyId = tokens::DOT;
 const XDOT: CurrencyId = tokens::XDOT;


### PR DESCRIPTION
adds `sp_std::vec::Vec` to benchmarking to fix docker build error.

this should fix the error on `master`