### PR TITLE
adds static application security testing workflow

### DIFF
--- a/.github/workflows/njsscan.yml
+++ b/.github/workflows/njsscan.yml
@@ -1,0 +1,18 @@
+name: njsscan
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+jobs:
+  njsscan:
+    runs-on: ubuntu-latest
+    name: njsscan check
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v2
+    - name: nodejsscan scan
+      id: njsscan
+      uses: ajinabraham/njsscan-action@master
+      with:
+        args: '.'


### PR DESCRIPTION
addresses `HAL-05`

enable static application security testing via a github workflow

uses workflow implementation of https://github.com/ajinabraham/njsscan