### PR TITLE
Handled Panic event in get_amounts_in

### DIFF
--- a/pallets/amm/src/lib.rs
+++ b/pallets/amm/src/lib.rs
@@ -132,6 +132,8 @@ pub mod pallet {
         InsufficientAmountOut,
         /// Insufficient amount in
         InsufficientAmountIn,
+        /// Insufficient supply out.
+        InsufficientSupplyOut,
         /// Identical assets
         IdenticalAssets,
         /// LP token has already been minted
@@ -624,6 +626,10 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
         reserve_in: BalanceOf<T, I>,
         reserve_out: BalanceOf<T, I>,
     ) -> Result<BalanceOf<T, I>, DispatchError> {
+        ensure!(
+            amount_out < reserve_out,
+            Error::<T, I>::InsufficientSupplyOut
+        );
         let numerator = reserve_in
             .checked_mul(amount_out)
             .ok_or(ArithmeticError::Overflow)?;

--- a/pallets/amm/src/tests.rs
+++ b/pallets/amm/src/tests.rs
@@ -718,6 +718,21 @@ fn amount_in_uneven_should_work() {
 }
 
 #[test]
+fn supply_out_should_larger_than_amount_out() {
+    // Test case for Panic when amount_out >= supply_out
+    new_test_ext().execute_with(|| {
+        let amount_out = 100_00;
+        let supply_in = 100_000;
+        let supply_out = 100_00;
+
+        assert_noop!(
+            AMM::get_amount_in(amount_out, supply_in, supply_out),
+            Error::<Test>::InsufficientSupplyOut
+        );
+    })
+}
+
+#[test]
 fn amount_out_and_in_should_work() {
     new_test_ext().execute_with(|| {
         let amount_out = 1_000;


### PR DESCRIPTION
Fixed Panic when `// Test case for Panic when amount_out >= supply_out`
Otherwise will Panic with error `ArithmeticError::Overflow`