### PR TITLE
rewrite fee calculation

### DIFF
--- a/pallets/amm/src/lib.rs
+++ b/pallets/amm/src/lib.rs
@@ -746,6 +746,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
             ideal_base_amount
                 .get_big_uint()
                 .checked_mul(&ideal_quote_amount.get_big_uint())
+                // loss of precision due to truncated sqrt
                 .map(|r| r.sqrt())
                 .and_then(|r| r.checked_sub(&T::MinimumLiquidity::get().get_big_uint()))
                 .ok_or(Error::<T, I>::ConversionToU128Failed)?
@@ -918,10 +919,13 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
             .base_amount
             .get_big_uint()
             .checked_mul(&pool.quote_amount.get_big_uint())
+            // loss of precision due to truncated sqrt
             .map(|r| r.sqrt())
             .ok_or(ArithmeticError::Overflow)?;
 
-        let root_k_last = k_last.sqrt();
+        let root_k_last = k_last
+            // loss of precision due to truncated sqrt
+            .sqrt();
 
         if root_k <= root_k_last {
             return Ok(Zero::zero());
@@ -945,6 +949,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
             .ok_or(Error::<T, I>::ConversionToU128Failed)?;
 
         let protocol_fees = numerator
+            // loss of precision due to truncated division
             .checked_div(&denominator)
             .ok_or(ArithmeticError::Underflow)?
             .to_u128()

--- a/pallets/amm/src/lib.rs
+++ b/pallets/amm/src/lib.rs
@@ -259,14 +259,14 @@ pub mod pallet {
                         Error::<T, I>::NotAnIdealPrice
                     );
 
+                    Self::do_mint_protocol_fee(pool)?;
+
                     Self::do_add_liquidity(
                         &who,
                         pool,
                         (ideal_base_amount, ideal_quote_amount),
                         (base_asset, quote_asset),
                     )?;
-
-                    Self::do_mint_protocol_fee(pool)?;
 
                     log::trace!(
                         target: "amm::add_liquidity",
@@ -313,9 +313,11 @@ pub mod pallet {
 
             Pools::<T, I>::try_mutate(base_asset, quote_asset, |pool| -> DispatchResult {
                 let pool = pool.as_mut().ok_or(Error::<T, I>::PoolDoesNotExist)?;
+
+                Self::do_mint_protocol_fee(pool)?;
+
                 let (base_amount_removed, quote_amount_removed) =
                     Self::do_remove_liquidity(&who, pool, liquidity, (base_asset, quote_asset))?;
-                Self::do_mint_protocol_fee(pool)?;
 
                 log::trace!(
                     target: "amm::remove_liquidity",
@@ -795,6 +797,13 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
             true,
         )?;
 
+        if Self::protocol_fee_on() {
+            // we cannot hold k_last for really large values
+            // we can hold two u128s instead
+            pool.base_amount_last = pool.base_amount;
+            pool.quote_amount_last = pool.quote_amount;
+        }
+
         log::trace!(
             target: "amm::do_add_liquidity",
             "who: {:?}, total_supply: {:?}, liquidity: {:?}, base_asset: {:?}, quote_asset: {:?}, ideal_base_amount: {:?},\
@@ -857,6 +866,13 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
         T::Assets::transfer(base_asset, &Self::account_id(), who, base_amount, false)?;
         T::Assets::transfer(quote_asset, &Self::account_id(), who, quote_amount, false)?;
 
+        if Self::protocol_fee_on() {
+            // we cannot hold k_last for really large values
+            // we can hold two u128s instead
+            pool.base_amount_last = pool.base_amount;
+            pool.quote_amount_last = pool.quote_amount;
+        }
+
         log::trace!(
             target: "amm::do_remove_liquidity",
             "who: {:?}, liquidity: {:?}, base_asset: {:?}, quote_asset: {:?}, base_amount: {:?}, quote_amount: {:?}",
@@ -877,55 +893,68 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
     ) -> Result<BalanceOf<T, I>, DispatchError> {
         // TODO: If we turn off protocol_fee later in runtime upgrade
         // this will reset root_k_last to zero which may not be good
-        if !Self::protocol_fee_on() || pool.root_k_last.is_zero() {
-            if !pool.root_k_last.is_zero() {
-                pool.root_k_last = Zero::zero();
+        let k_last = pool
+            .base_amount_last
+            .get_big_uint()
+            .checked_mul(&pool.quote_amount_last.get_big_uint())
+            .ok_or(ArithmeticError::Overflow)?;
+
+        if !Self::protocol_fee_on() {
+            // if fees are off and k_last is a value we need to reset it
+            if !k_last.is_zero() {
+                pool.base_amount_last = Zero::zero();
+                pool.quote_amount_last = Zero::zero();
+                return Ok(Zero::zero());
             }
+
+            // if fees are off and k_last is zero return
             return Ok(Zero::zero());
         }
+
+        // if the early exits do not return we know that k_last is not zero
+        // and that protocol fees are on
 
         let root_k = pool
             .base_amount
             .get_big_uint()
             .checked_mul(&pool.quote_amount.get_big_uint())
             .map(|r| r.sqrt())
-            .ok_or(Error::<T, I>::ConversionToU128Failed)?
-            .to_u128()
             .ok_or(ArithmeticError::Overflow)?;
 
-        if root_k <= pool.root_k_last {
+        let root_k_last = k_last.sqrt();
+
+        if root_k <= root_k_last {
             return Ok(Zero::zero());
         }
 
-        let total_supply = T::Assets::total_issuance(pool.lp_token_id);
+        let total_supply = T::Assets::total_issuance(pool.lp_token_id).get_big_uint();
 
         let numerator = root_k
-            .get_big_uint()
-            .checked_sub(&pool.root_k_last.get_big_uint())
-            .and_then(|r| r.checked_mul(&total_supply.get_big_uint()))
-            .ok_or(Error::<T, I>::ConversionToU128Failed)?
-            .to_u128()
-            .ok_or(ArithmeticError::Overflow)?;
+            .checked_sub(&root_k_last)
+            .and_then(|r| r.checked_mul(&total_supply))
+            .ok_or(Error::<T, I>::ConversionToU128Failed)?;
+
+        let scalar = Self::get_protocol_fee_reciprocal_proportion()?
+            .checked_sub(One::one())
+            .ok_or(ArithmeticError::Underflow)?
+            .get_big_uint();
 
         let denominator = root_k
-            .get_big_uint()
-            .checked_mul(&Self::get_protocol_fee_reciprocal_proportion()?.get_big_uint())
-            .and_then(|r| r.checked_add(&pool.root_k_last.get_big_uint()))
-            .ok_or(Error::<T, I>::ConversionToU128Failed)?
-            .to_u128()
-            .ok_or(ArithmeticError::Overflow)?;
+            .checked_mul(&scalar)
+            .and_then(|r| r.checked_add(&root_k_last))
+            .ok_or(Error::<T, I>::ConversionToU128Failed)?;
 
         let protocol_fees = numerator
-            .checked_div(denominator)
-            .ok_or(ArithmeticError::Underflow)?;
+            .checked_div(&denominator)
+            .ok_or(ArithmeticError::Underflow)?
+            .to_u128()
+            .ok_or(ArithmeticError::Overflow)?;
 
         T::Assets::mint_into(
             pool.lp_token_id,
             &T::ProtocolFeeReceiver::get(),
             protocol_fees,
         )?;
-
-        pool.root_k_last = root_k;
 
         log::trace!(
             target: "amm::do_mint_protocol_fee",
@@ -936,7 +965,6 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
             &denominator,
             &protocol_fees
         );
-
         Ok(protocol_fees)
     }
 

--- a/pallets/amm/src/mock.rs
+++ b/pallets/amm/src/mock.rs
@@ -26,6 +26,7 @@ pub const BOB: AccountId = AccountId(2);
 pub const CHARLIE: AccountId = AccountId(3);
 pub const EVE: AccountId = AccountId(4);
 pub const FRANK: AccountId = AccountId(5);
+pub const PROTOCOL_FEE_RECEIVER: AccountId = AccountId(99);
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
@@ -154,7 +155,7 @@ parameter_types! {
     pub const AMMPalletId: PalletId = PalletId(*b"par/ammp");
     pub DefaultLpFee: Ratio = Ratio::from_rational(25u32, 10000u32);        // 0.25%
     pub DefaultProtocolFee: Ratio = Ratio::from_rational(5u32, 10000u32);   // 0.05%
-    pub const DefaultProtocolFeeReceiver: AccountId = AccountId(4_u64);
+    pub const DefaultProtocolFeeReceiver: AccountId = PROTOCOL_FEE_RECEIVER;
     pub const MinimumLiquidity: u128 = 1_000u128;
     pub const LockAccountId: AccountId = AccountId(1_u64);
     pub const MaxLengthRoute: u8 = 10;
@@ -218,7 +219,13 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 
         Assets::mint(Origin::signed(ALICE), tokens::DOT, ALICE, 100_000_000).unwrap();
 
-        Assets::mint(Origin::signed(ALICE), tokens::DOT, BOB, 100_000_000).unwrap();
+        Assets::mint(
+            Origin::signed(ALICE),
+            tokens::DOT,
+            BOB,
+            100_000_000_000_000_000_000,
+        )
+        .unwrap();
         Assets::mint(Origin::signed(ALICE), tokens::DOT, CHARLIE, 1000_000_000).unwrap();
         Assets::mint(Origin::signed(ALICE), tokens::DOT, EVE, 1000_000_000).unwrap();
         Assets::mint(
@@ -230,7 +237,13 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
         .unwrap();
 
         Assets::mint(Origin::signed(ALICE), tokens::XDOT, ALICE, 100_000_000).unwrap();
-        Assets::mint(Origin::signed(ALICE), tokens::XDOT, BOB, 100_000_000).unwrap();
+        Assets::mint(
+            Origin::signed(ALICE),
+            tokens::XDOT,
+            BOB,
+            100_000_000_000_000_000_000,
+        )
+        .unwrap();
         Assets::mint(Origin::signed(ALICE), tokens::XDOT, CHARLIE, 1000_000_000).unwrap();
         Assets::mint(Origin::signed(ALICE), tokens::XDOT, EVE, 1000_000_000).unwrap();
 

--- a/pallets/amm/src/types.rs
+++ b/pallets/amm/src/types.rs
@@ -20,7 +20,8 @@ use sp_runtime::{traits::Zero, RuntimeDebug};
 pub struct Pool<CurrencyId, Balance, BlockNumber> {
     pub base_amount: Balance,
     pub quote_amount: Balance,
-    pub root_k_last: Balance,
+    pub base_amount_last: Balance,
+    pub quote_amount_last: Balance,
     pub lp_token_id: CurrencyId,
     pub block_timestamp_last: BlockNumber,
     pub price_0_cumulative_last: Balance,
@@ -32,7 +33,8 @@ impl<CurrencyId, Balance: BalanceT, BlockNumber: BalanceT> Pool<CurrencyId, Bala
         Self {
             base_amount: Zero::zero(),
             quote_amount: Zero::zero(),
-            root_k_last: Zero::zero(),
+            base_amount_last: Zero::zero(),
+            quote_amount_last: Zero::zero(),
             lp_token_id,
             block_timestamp_last: Zero::zero(),
             price_0_cumulative_last: Zero::zero(),


### PR DESCRIPTION
notes

- [X] protocol fees should be calculate before liquidity is added/removed
- [X] k last cannot be stored because it can be `> u128` so we need to store previous base and quote values
- [X] protocol fees should use bigUint for calculations
- [X] test should check for protocol fee accumulation

~~todo:~~
~~revisit rounding issue, maybe we should use a fixedu128?~~

update:
assume loss or precision when calculating `sqrt` and `div`. This will result in a vert small loss of protocol fees and slight gain in LP fees for liquidity providers in this case