### PR TITLE
make amm aware of native tokens

### DIFF
--- a/pallets/amm/src/lib.rs
+++ b/pallets/amm/src/lib.rs
@@ -120,7 +120,7 @@ pub mod pallet {
         type MaxLengthRoute: Get<u32>;
 
         #[pallet::constant]
-        type GetNativeCurrencyId: Get<u32>;
+        type GetNativeCurrencyId: Get<AssetIdOf<Self, I>>;
     }
 
     #[pallet::error]

--- a/pallets/amm/src/lib.rs
+++ b/pallets/amm/src/lib.rs
@@ -118,6 +118,9 @@ pub mod pallet {
         /// How many routes we support at most
         #[pallet::constant]
         type MaxLengthRoute: Get<u32>;
+
+        #[pallet::constant]
+        type GetNativeCurrencyId: Get<u32>;
     }
 
     #[pallet::error]
@@ -789,14 +792,14 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
             who,
             &Self::account_id(),
             ideal_base_amount,
-            true,
+            base_asset == T::GetNativeCurrencyId::get(), // should keep alive if is native
         )?;
         T::Assets::transfer(
             quote_asset,
             who,
             &Self::account_id(),
             ideal_quote_amount,
-            true,
+            quote_asset == T::GetNativeCurrencyId::get(), // should keep alive if is native
         )?;
 
         if Self::protocol_fee_on() {
@@ -865,8 +868,20 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
             .ok_or(Error::<T, I>::InsufficientLiquidity)?;
 
         T::Assets::burn_from(pool.lp_token_id, who, liquidity)?;
-        T::Assets::transfer(base_asset, &Self::account_id(), who, base_amount, false)?;
-        T::Assets::transfer(quote_asset, &Self::account_id(), who, quote_amount, false)?;
+        T::Assets::transfer(
+            base_asset,
+            &Self::account_id(),
+            who,
+            base_amount,
+            base_asset == T::GetNativeCurrencyId::get(), // should keep alive if is native
+        )?;
+        T::Assets::transfer(
+            quote_asset,
+            &Self::account_id(),
+            who,
+            quote_amount,
+            quote_asset == T::GetNativeCurrencyId::get(), // should keep alive if is native
+        )?;
 
         if Self::protocol_fee_on() {
             // we cannot hold k_last for really large values
@@ -1020,8 +1035,20 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 
                 Self::do_update_oracle(pool)?;
 
-                T::Assets::transfer(asset_in, who, &Self::account_id(), amount_in, true)?;
-                T::Assets::transfer(asset_out, &Self::account_id(), who, amount_out, false)?;
+                T::Assets::transfer(
+                    asset_in,
+                    who,
+                    &Self::account_id(),
+                    amount_in,
+                    asset_in == T::GetNativeCurrencyId::get(), // should keep alive if is native
+                )?;
+                T::Assets::transfer(
+                    asset_out,
+                    &Self::account_id(),
+                    who,
+                    amount_out,
+                    asset_out == T::GetNativeCurrencyId::get(), // should keep alive if is native
+                )?;
 
                 log::trace!(
                     target: "amm::do_trade",

--- a/pallets/amm/src/mock.rs
+++ b/pallets/amm/src/mock.rs
@@ -180,6 +180,7 @@ impl pallet_amm::Config for Test {
     type MinimumLiquidity = MinimumLiquidity;
     type ProtocolFeeReceiver = DefaultProtocolFeeReceiver;
     type MaxLengthRoute = MaxLengthRoute;
+    type GetNativeCurrencyId = NativeCurrencyId;
 }
 
 parameter_types! {

--- a/pallets/router/src/mock.rs
+++ b/pallets/router/src/mock.rs
@@ -147,6 +147,7 @@ impl pallet_amm::Config for Runtime {
     type MinimumLiquidity = MinimumLiquidity;
     type ProtocolFeeReceiver = DefaultProtocolFeeReceiver;
     type MaxLengthRoute = MaxLengthRoute;
+    type GetNativeCurrencyId = NativeCurrencyId;
 }
 
 parameter_types! {

--- a/runtime/heiko/src/lib.rs
+++ b/runtime/heiko/src/lib.rs
@@ -1756,6 +1756,7 @@ impl pallet_amm::Config for Runtime {
     type MinimumLiquidity = MinimumLiquidity;
     type ProtocolFeeReceiver = DefaultProtocolFeeReceiver;
     type MaxLengthRoute = MaxLengthRoute;
+    type GetNativeCurrencyId = NativeCurrencyId;
 }
 
 parameter_types! {

--- a/runtime/kerria/src/lib.rs
+++ b/runtime/kerria/src/lib.rs
@@ -1684,6 +1684,7 @@ impl pallet_amm::Config for Runtime {
     type MinimumLiquidity = MinimumLiquidity;
     type ProtocolFeeReceiver = DefaultProtocolFeeReceiver;
     type MaxLengthRoute = MaxLengthRoute;
+    type GetNativeCurrencyId = NativeCurrencyId;
 }
 
 parameter_types! {

--- a/runtime/parallel/src/lib.rs
+++ b/runtime/parallel/src/lib.rs
@@ -1703,6 +1703,7 @@ impl pallet_amm::Config for Runtime {
     type MinimumLiquidity = MinimumLiquidity;
     type ProtocolFeeReceiver = DefaultProtocolFeeReceiver;
     type MaxLengthRoute = MaxLengthRoute;
+    type GetNativeCurrencyId = NativeCurrencyId;
 }
 
 parameter_types! {

--- a/runtime/vanilla/src/lib.rs
+++ b/runtime/vanilla/src/lib.rs
@@ -1773,6 +1773,7 @@ impl pallet_amm::Config for Runtime {
     type MinimumLiquidity = MinimumLiquidity;
     type ProtocolFeeReceiver = DefaultProtocolFeeReceiver;
     type MaxLengthRoute = MaxLengthRoute;
+    type GetNativeCurrencyId = NativeCurrencyId;
 }
 
 parameter_types! {


### PR DESCRIPTION
currently the `keep_alive` check prohibits users from transferring their full balances when swapping. This causes an error with the "Max" button on the frontend and results in dust.

This PR adds the `GetNativeCurrencyId` to the AMM so we can check if a user is attempting to transfer native tokens. We should only use the `keep_alive` flag on native balances and set it false for all assets. This way users can transfer 100% of their assets that are not native