### PR TITLE
remove related storage when delete a stream

### DIFF
--- a/pallets/streaming/src/lib.rs
+++ b/pallets/streaming/src/lib.rs
@@ -254,11 +254,10 @@ pub mod pallet {
             Streams::<T>::insert(stream_id, stream);
 
             // Remove the outdated and finished streams
-            Self::update_finished_stream_library(&sender)?;
-            Self::update_finished_stream_library(&recipient)?;
+            Self::update_finished_stream_library(&sender, &recipient)?;
             // Add the stream_id to stream_library for both the sender and receiver.
-            Self::try_push_stream_library(&sender, StreamKind::Send, stream_id)?;
-            Self::try_push_stream_library(&recipient, StreamKind::Receive, stream_id)?;
+            Self::try_push_stream_library(&sender, stream_id, StreamKind::Send)?;
+            Self::try_push_stream_library(&recipient, stream_id, StreamKind::Receive)?;
 
             Self::deposit_event(Event::<T>::StreamCreated(
                 stream_id, sender, recipient, deposit, asset_id, start_time, end_time, true,
@@ -303,8 +302,8 @@ pub mod pallet {
             stream.try_cancel(sender_balance)?;
             Streams::<T>::insert(stream_id, stream.clone());
 
-            Self::try_push_stream_library(&stream.sender, StreamKind::Finish, stream_id)?;
-            Self::try_push_stream_library(&stream.recipient, StreamKind::Finish, stream_id)?;
+            Self::try_push_stream_library(&stream.sender, stream_id, StreamKind::Finish)?;
+            Self::try_push_stream_library(&stream.recipient, stream_id, StreamKind::Finish)?;
 
             Self::deposit_event(Event::<T>::StreamCancelled(
                 stream_id,
@@ -345,8 +344,8 @@ pub mod pallet {
             stream.try_deduct(amount)?;
             stream.try_complete()?;
             if stream.has_finished() {
-                Self::try_push_stream_library(&stream.sender, StreamKind::Finish, stream_id)?;
-                Self::try_push_stream_library(&recipient, StreamKind::Finish, stream_id)?;
+                Self::try_push_stream_library(&stream.sender, stream_id, StreamKind::Finish)?;
+                Self::try_push_stream_library(&recipient, stream_id, StreamKind::Finish)?;
             }
             Streams::<T>::insert(stream_id, stream.clone());
 
@@ -412,7 +411,10 @@ impl<T: Config> Pallet<T> {
         Ok(duration)
     }
 
-    pub fn update_finished_stream_library(account: &AccountOf<T>) -> DispatchResult {
+    pub fn update_finished_stream_library(
+        sender: &AccountOf<T>,
+        recipient: &AccountOf<T>,
+    ) -> DispatchResult {
         let checked_pop =
             |registry: &mut Option<BoundedVec<StreamId, T::MaxStreamsCount>>| -> DispatchResult {
                 let mut r = registry.take().unwrap_or_default();
@@ -423,15 +425,11 @@ impl<T: Config> Pallet<T> {
                     _x if len >= T::MaxFinishedStreamsCount::get() => {
                         if let Some(stream_id) = r.pop() {
                             if Streams::<T>::get(stream_id).is_some() {
+                                // Remove all related storage
                                 Streams::<T>::remove(stream_id);
+                                Self::try_remove_stream_library(sender, stream_id, None)?;
+                                Self::try_remove_stream_library(recipient, stream_id, None)?;
                             }
-
-                            Self::try_remove_stream_library(account, StreamKind::Send, stream_id)?;
-                            Self::try_remove_stream_library(
-                                account,
-                                StreamKind::Receive,
-                                stream_id,
-                            )?;
                         }
                     }
                     _ => {}
@@ -441,15 +439,16 @@ impl<T: Config> Pallet<T> {
                 Ok(())
             };
 
-        StreamLibrary::<T>::try_mutate(account, &StreamKind::Finish, checked_pop)?;
+        StreamLibrary::<T>::try_mutate(sender, &StreamKind::Finish, checked_pop)?;
+        StreamLibrary::<T>::try_mutate(recipient, &StreamKind::Finish, checked_pop)?;
 
         Ok(())
     }
 
     pub fn try_push_stream_library(
         account: &AccountOf<T>,
-        kind: StreamKind,
         stream_id: StreamId,
+        kind: StreamKind,
     ) -> DispatchResult {
         let checked_push =
             |registry: &mut Option<BoundedVec<StreamId, T::MaxStreamsCount>>| -> DispatchResult {
@@ -466,8 +465,8 @@ impl<T: Config> Pallet<T> {
 
     pub fn try_remove_stream_library(
         account: &AccountOf<T>,
-        kind: StreamKind,
         stream_id: StreamId,
+        kind: Option<StreamKind>,
     ) -> DispatchResult {
         let checked_remove =
             |registry: &mut Option<BoundedVec<StreamId, T::MaxStreamsCount>>| -> DispatchResult {
@@ -479,7 +478,14 @@ impl<T: Config> Pallet<T> {
                 Ok(())
             };
 
-        StreamLibrary::<T>::try_mutate(account, &kind, checked_remove)?;
+        if let Some(k) = kind {
+            StreamLibrary::<T>::try_mutate(account, &k, checked_remove)?;
+        } else {
+            StreamLibrary::<T>::try_mutate(account, StreamKind::Send, checked_remove)?;
+            StreamLibrary::<T>::try_mutate(account, StreamKind::Receive, checked_remove)?;
+            StreamLibrary::<T>::try_mutate(account, StreamKind::Finish, checked_remove)?;
+        }
+
         Ok(())
     }
 }

--- a/pallets/streaming/src/tests.rs
+++ b/pallets/streaming/src/tests.rs
@@ -380,12 +380,6 @@ fn max_finished_streams_count_should_work() {
             false
         );
         assert_eq!(
-            StreamLibrary::<Test>::get(ALICE, StreamKind::Finish)
-                .unwrap()
-                .contains(&stream_id_1),
-            true
-        );
-        assert_eq!(
             StreamLibrary::<Test>::get(ALICE, StreamKind::Send)
                 .unwrap()
                 .contains(&stream_id_0),
@@ -396,6 +390,18 @@ fn max_finished_streams_count_should_work() {
                 .unwrap()
                 .contains(&stream_id_0),
             false
+        );
+        assert_eq!(
+            StreamLibrary::<Test>::get(ALICE, StreamKind::Finish)
+                .unwrap()
+                .contains(&stream_id_1),
+            true
+        );
+        assert_eq!(
+            StreamLibrary::<Test>::get(ALICE, StreamKind::Send)
+                .unwrap()
+                .contains(&stream_id_1),
+            true
         );
 
         assert_eq!(
@@ -419,12 +425,6 @@ fn max_finished_streams_count_should_work() {
 
         assert_eq!(
             StreamLibrary::<Test>::get(DAVE, StreamKind::Finish)
-                .unwrap()
-                .contains(&stream_id_1),
-            true
-        );
-        assert_eq!(
-            StreamLibrary::<Test>::get(DAVE, StreamKind::Send)
                 .unwrap()
                 .contains(&stream_id_1),
             true

--- a/pallets/streaming/src/tests.rs
+++ b/pallets/streaming/src/tests.rs
@@ -87,7 +87,7 @@ fn cancel_works_without_withdrawal() {
         // Bob cannot access to previous stream
         assert_err!(
             Streaming::withdraw(Origin::signed(BOB), stream_id_0, 1),
-            Error::<Test>::StreamHasFinished
+            Error::<Test>::HasFinished
         );
 
         // If steam is as collateral, it cannot be cancelled
@@ -137,6 +137,11 @@ fn withdraw_works() {
             Error::<Test>::NotTheRecipient
         );
 
+        // Stream not started
+        assert_err!(
+            Streaming::withdraw(Origin::signed(BOB), 0, 1),
+            Error::<Test>::NotStarted
+        );
         // Time passes for 1 second
         assert_eq!(TimestampPallet::now(), 6000);
         // 6000(init) + 2000(ms)
@@ -251,7 +256,7 @@ fn cancel_works_with_withdrawal() {
         // Bob cannot access to previous stream
         assert_err!(
             Streaming::withdraw(Origin::signed(BOB), 0, 1),
-            Error::<Test>::StreamHasFinished,
+            Error::<Test>::HasFinished,
         );
     });
 }
@@ -331,11 +336,6 @@ fn max_finished_streams_count_should_work() {
             dollar(10)
         ));
 
-        // StreamLibrary should contains stream_id_0
-        assert_ok!(StreamLibrary::<Test>::get(ALICE, StreamKind::Finish)
-            .unwrap()
-            .binary_search(&stream_id_0));
-
         let stream_id_1 = NextStreamId::<Test>::get();
         assert_ok!(Streaming::create(
             Origin::signed(ALICE),
@@ -354,11 +354,7 @@ fn max_finished_streams_count_should_work() {
         ));
         assert_ok!(Streaming::cancel(Origin::signed(ALICE), stream_id_1));
 
-        // StreamLibrary should contains stream_id_1
-        assert_ok!(StreamLibrary::<Test>::get(ALICE, StreamKind::Finish)
-            .unwrap()
-            .binary_search(&stream_id_1));
-
+        // StreamLibrary should contains stream_id_1, stream_id_0
         assert_ok!(Streaming::create(
             Origin::signed(ALICE),
             BOB,
@@ -370,70 +366,190 @@ fn max_finished_streams_count_should_work() {
         ));
 
         // storage should be removed due to MaxFinishedStreamsCount = 2
-        // Alice: [1, 0], pop 0, push 2 => vec![2, 1]
-        // Bob: [2, 0], pop 0 => vec![2]
-        // DAVE: [1] => vec![1]
         assert_eq!(
             StreamLibrary::<Test>::get(ALICE, StreamKind::Finish)
                 .unwrap()
-                .contains(&stream_id_0),
-            false
+                .to_vec(),
+            vec![1, 0]
         );
         assert_eq!(
             StreamLibrary::<Test>::get(ALICE, StreamKind::Send)
                 .unwrap()
-                .contains(&stream_id_0),
-            false
+                .to_vec(),
+            vec![2, 1, 0]
         );
         assert_eq!(
             StreamLibrary::<Test>::get(ALICE, StreamKind::Receive)
-                .unwrap()
-                .contains(&stream_id_0),
-            false
-        );
-        assert_eq!(
-            StreamLibrary::<Test>::get(ALICE, StreamKind::Finish)
-                .unwrap()
-                .contains(&stream_id_1),
-            true
-        );
-        assert_eq!(
-            StreamLibrary::<Test>::get(ALICE, StreamKind::Send)
-                .unwrap()
-                .contains(&stream_id_1),
-            true
+                .unwrap_or_default()
+                .to_vec(),
+            vec![]
         );
 
         assert_eq!(
             StreamLibrary::<Test>::get(BOB, StreamKind::Finish)
-                .unwrap()
-                .contains(&stream_id_0),
-            false
+                .unwrap_or_default()
+                .to_vec(),
+            vec![0]
         );
         assert_eq!(
             StreamLibrary::<Test>::get(BOB, StreamKind::Send)
-                .unwrap()
-                .contains(&stream_id_0),
-            false
+                .unwrap_or_default()
+                .to_vec(),
+            vec![]
         );
         assert_eq!(
             StreamLibrary::<Test>::get(BOB, StreamKind::Receive)
                 .unwrap()
-                .contains(&stream_id_0),
-            false
+                .to_vec(),
+            vec![2, 0]
         );
 
         assert_eq!(
             StreamLibrary::<Test>::get(DAVE, StreamKind::Finish)
                 .unwrap()
-                .contains(&stream_id_1),
-            true
+                .to_vec(),
+            vec![1]
+        );
+        assert_eq!(
+            StreamLibrary::<Test>::get(DAVE, StreamKind::Send)
+                .unwrap_or_default()
+                .to_vec(),
+            vec![]
         );
         assert_eq!(
             StreamLibrary::<Test>::get(DAVE, StreamKind::Receive)
                 .unwrap()
-                .contains(&stream_id_1),
-            true
+                .to_vec(),
+            vec![1]
+        );
+
+        // Alice create many streams
+        let stream_id_3 = NextStreamId::<Test>::get();
+        assert_ok!(Streaming::create(
+            Origin::signed(ALICE),
+            BOB,
+            dollar(10),
+            DOT,
+            16,
+            30,
+            true,
+        ));
+        let stream_id_4 = NextStreamId::<Test>::get();
+        assert_ok!(Streaming::create(
+            Origin::signed(ALICE),
+            BOB,
+            dollar(10),
+            DOT,
+            16,
+            30,
+            true,
+        ));
+        assert_ok!(Streaming::cancel(Origin::signed(ALICE), stream_id_3));
+        assert_eq!(
+            StreamLibrary::<Test>::get(ALICE, StreamKind::Finish)
+                .unwrap()
+                .to_vec(),
+            vec![3, 1]
+        );
+        assert_eq!(
+            StreamLibrary::<Test>::get(ALICE, StreamKind::Send)
+                .unwrap()
+                .to_vec(),
+            vec![4, 3, 2, 1]
+        );
+        assert_ok!(Streaming::cancel(Origin::signed(ALICE), stream_id_4));
+        assert_eq!(
+            StreamLibrary::<Test>::get(ALICE, StreamKind::Finish)
+                .unwrap()
+                .to_vec(),
+            vec![4, 3]
+        );
+        assert_eq!(
+            StreamLibrary::<Test>::get(ALICE, StreamKind::Send)
+                .unwrap()
+                .to_vec(),
+            vec![4, 3, 2]
+        );
+        // BOB create some streams
+        let stream_id_5 = NextStreamId::<Test>::get();
+        assert_ok!(Streaming::create(
+            Origin::signed(BOB),
+            DAVE,
+            dollar(3),
+            DOT,
+            16,
+            30,
+            true,
+        ));
+        // let stream_id_6= NextStreamId::<Test>::get();
+        assert_ok!(Streaming::create(
+            Origin::signed(BOB),
+            ALICE,
+            dollar(3),
+            DOT,
+            16,
+            30,
+            true,
+        ));
+        assert_ok!(Streaming::cancel(Origin::signed(BOB), stream_id_5));
+        // assert_ok!(Streaming::cancel(Origin::signed(BOB), stream_id_6));
+
+        // storage should be removed due to MaxFinishedStreamsCount = 2
+        assert_eq!(
+            StreamLibrary::<Test>::get(ALICE, StreamKind::Finish)
+                .unwrap()
+                .to_vec(),
+            vec![4]
+        );
+        assert_eq!(
+            StreamLibrary::<Test>::get(ALICE, StreamKind::Send)
+                .unwrap()
+                .to_vec(),
+            vec![4, 2]
+        );
+        assert_eq!(
+            StreamLibrary::<Test>::get(ALICE, StreamKind::Receive)
+                .unwrap()
+                .to_vec(),
+            vec![6]
+        );
+
+        assert_eq!(
+            StreamLibrary::<Test>::get(BOB, StreamKind::Finish)
+                .unwrap()
+                .to_vec(),
+            vec![5, 4]
+        );
+        assert_eq!(
+            StreamLibrary::<Test>::get(BOB, StreamKind::Send)
+                .unwrap()
+                .to_vec(),
+            vec![6, 5]
+        );
+        assert_eq!(
+            StreamLibrary::<Test>::get(BOB, StreamKind::Receive)
+                .unwrap()
+                .to_vec(),
+            vec![4, 2]
+        );
+
+        assert_eq!(
+            StreamLibrary::<Test>::get(DAVE, StreamKind::Finish)
+                .unwrap()
+                .to_vec(),
+            vec![5]
+        );
+        assert_eq!(
+            StreamLibrary::<Test>::get(DAVE, StreamKind::Send)
+                .unwrap_or_default()
+                .to_vec(),
+            vec![]
+        );
+        assert_eq!(
+            StreamLibrary::<Test>::get(DAVE, StreamKind::Receive)
+                .unwrap()
+                .to_vec(),
+            vec![5]
         );
     })
 }

--- a/pallets/streaming/src/types.rs
+++ b/pallets/streaming/src/types.rs
@@ -106,6 +106,12 @@ impl<T: Config> Stream<T> {
         }
     }
 
+    pub fn has_started(&self) -> Result<bool, DispatchError> {
+        let delta = self.delta_of()? as BalanceOf<T>;
+
+        Ok(!delta.is_zero())
+    }
+
     fn claimed_balance(&self) -> Result<BalanceOf<T>, DispatchError> {
         Ok(self
             .deposit


### PR DESCRIPTION
## Context

Fix a situation by deleting all storage

### Case

Both An and B record stream X. if A need to delete X (reaches the Completed threshold), but B need not delete X, then whether to delete X or not?

### Solution

Delete all