### PR TITLE
Filter lp token with only lf enabled

### DIFF
--- a/pallets/prices/src/lib.rs
+++ b/pallets/prices/src/lib.rs
@@ -336,7 +336,7 @@ impl<T: Config> PriceFeeder for Pallet<T> {
                     true => Self::get_staking_asset_detail_price(asset_id, mantissa, base_price),
                     false => match is_vault_token(*asset_id) {
                         true => Self::get_vault_asset_detail_price(asset_id, mantissa, base_price),
-                        false => match is_lp_token(*asset_id) {
+                        false => match is_lf_lp_token(*asset_id) {
                             true => Self::get_lp_vault_asset_detail_price(
                                 asset_id, mantissa, base_price,
                             ),
@@ -374,7 +374,7 @@ impl<T: Config> DataProviderExtended<CurrencyId, TimeStampedPrice> for Pallet<T>
                 true => Self::get_staking_asset_price(asset_id, base_price),
                 false => match is_vault_token(*asset_id) {
                     true => Self::get_vault_asset_price(asset_id, base_price),
-                    false => match is_lp_token(*asset_id) {
+                    false => match is_lf_lp_token(*asset_id) {
                         true => Self::get_lp_vault_asset_price(asset_id, mantissa, base_price),
                         false => T::Source::get_no_op(asset_id),
                     },

--- a/pallets/prices/src/lib.rs
+++ b/pallets/prices/src/lib.rs
@@ -332,19 +332,16 @@ impl<T: Config> PriceFeeder for Pallet<T> {
         Self::get_emergency_price(asset_id).or_else(|| {
             let mantissa = Self::get_asset_mantissa(asset_id)?;
             if let Some(base_price) = T::Source::get(&T::RelayCurrency::get()) {
-                return match is_ls_token(*asset_id) {
-                    true => Self::get_staking_asset_detail_price(asset_id, mantissa, base_price),
-                    false => match is_vault_token(*asset_id) {
-                        true => Self::get_vault_asset_detail_price(asset_id, mantissa, base_price),
-                        false => match is_lf_lp_token(*asset_id) {
-                            true => Self::get_lp_vault_asset_detail_price(
-                                asset_id, mantissa, base_price,
-                            ),
-                            false => T::Source::get(asset_id)
-                                .and_then(|price| Self::normalize_detail_price(price, mantissa)),
-                        },
-                    },
-                };
+                if is_ls_token(*asset_id) {
+                    return Self::get_staking_asset_detail_price(asset_id, mantissa, base_price);
+                } else if is_vault_token(*asset_id) {
+                    return Self::get_vault_asset_detail_price(asset_id, mantissa, base_price);
+                } else if is_lf_lp_token(*asset_id) {
+                    return Self::get_lp_vault_asset_detail_price(asset_id, mantissa, base_price);
+                } else {
+                    return T::Source::get(asset_id)
+                        .and_then(|price| Self::normalize_detail_price(price, mantissa));
+                }
             }
             T::Source::get(asset_id).and_then(|price| Self::normalize_detail_price(price, mantissa))
         })
@@ -370,16 +367,15 @@ impl<T: Config> DataProviderExtended<CurrencyId, TimeStampedPrice> for Pallet<T>
     fn get_no_op(asset_id: &CurrencyId) -> Option<TimeStampedPrice> {
         let mantissa = Self::get_asset_mantissa(asset_id)?;
         if let Some(base_price) = T::Source::get_no_op(&T::RelayCurrency::get()) {
-            return match is_ls_token(*asset_id) {
-                true => Self::get_staking_asset_price(asset_id, base_price),
-                false => match is_vault_token(*asset_id) {
-                    true => Self::get_vault_asset_price(asset_id, base_price),
-                    false => match is_lf_lp_token(*asset_id) {
-                        true => Self::get_lp_vault_asset_price(asset_id, mantissa, base_price),
-                        false => T::Source::get_no_op(asset_id),
-                    },
-                },
-            };
+            if is_ls_token(*asset_id) {
+                return Self::get_staking_asset_price(asset_id, base_price);
+            } else if is_vault_token(*asset_id) {
+                return Self::get_vault_asset_price(asset_id, base_price);
+            } else if is_lf_lp_token(*asset_id) {
+                return Self::get_lp_vault_asset_price(asset_id, mantissa, base_price);
+            } else {
+                return T::Source::get_no_op(asset_id);
+            }
         }
         T::Source::get_no_op(asset_id)
     }

--- a/primitives/src/tokens.rs
+++ b/primitives/src/tokens.rs
@@ -114,12 +114,15 @@ pub const CDOT_6_13: CurrencyId = 200060013;
 pub const CDOT_7_14: CurrencyId = 200070014;
 pub const CDOT_8_15: CurrencyId = 200080015;
 
+// assume all vault token are liquidation free and within range here
 pub fn is_vault_token(asset_id: CurrencyId) -> bool {
     asset_id > 100000000 && asset_id < 300000000
 }
 
-pub fn is_lp_token(asset_id: CurrencyId) -> bool {
-    (5000..7000).contains(&asset_id)
+// we only care about liquidation fee lp tokens here
+// which constructed with vault token and relay token
+pub fn is_lf_lp_token(asset_id: CurrencyId) -> bool {
+    (asset_id > 5003 && asset_id < 6000) || (asset_id > 6003 && asset_id < 7000)
 }
 
 pub fn is_ls_token(asset_id: CurrencyId) -> bool {


### PR DESCRIPTION
see some chain logs as following, to avoid unnecessary match we filter these lp assets out of the scope

```
2022-05-26 10:46:12.441  WARN ThreadId(95) prices::get_lp_vault_asset_price: Could not get price for asset 6000 will fall back to oracle
2022-05-26 10:46:12.443  WARN ThreadId(95) prices::get_lp_vault_asset_price: Could not get price for asset 6001 will fall back to oracle
2022-05-26 10:46:12.449  WARN ThreadId(95) prices::get_lp_vault_asset_price: Could not get price for asset 6001 will fall back to oracle
2022-05-26 10:46:12.813  WARN ThreadId(95) prices::get_lp_vault_asset_price: Could not get price for asset 6002 will fall back to oracle
```

we can wait to merge this pr after integration test finished