### PR TITLE
Introduce hbtc to para

### DIFF
--- a/primitives/src/tokens.rs
+++ b/primitives/src/tokens.rs
@@ -48,6 +48,7 @@ pub const TUR: CurrencyId = 125;
 // Ethereum ecosystem
 pub const EUSDT: CurrencyId = 201;
 pub const EUSDC: CurrencyId = 202;
+pub const HBTC: CurrencyId = 203;
 
 // Liquid Staking Derivative
 pub const SKSM: CurrencyId = 1000;


### PR DESCRIPTION
This pr only define asset id for hbtc and update oracle config to support feeding price. we may need some bridge solution to genuinely introduce it