### PR TITLE
Loans trait for fast unstake

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,10 @@ check-helper:
 test:
 	SKIP_WASM_BUILD= cargo test --workspace --features runtime-benchmarks --exclude runtime-integration-tests --exclude parallel --exclude parallel-runtime --exclude vanilla-runtime --exclude kerria-runtime --exclude heiko-runtime --exclude pallet-loans-rpc --exclude pallet-loans-rpc-runtime-api --exclude parallel-primitives -- --nocapture
 
+.PHONY: fast-test-loans
+fast-test-loans:
+	SKIP_WASM_BUILD= cargo test -p pallet-loans --lib --no-fail-fast -- --nocapture
+
 .PHONY: fast-test-crowdloan
 fast-test-crowdloan:
 	SKIP_WASM_BUILD= cargo test -p pallet-crowdloans --lib --no-fail-fast -- --nocapture

--- a/pallets/loans/src/lib.rs
+++ b/pallets/loans/src/lib.rs
@@ -39,7 +39,10 @@ use frame_support::{
 use frame_system::pallet_prelude::*;
 use num_traits::cast::ToPrimitive;
 pub use pallet::*;
-use pallet_traits::{ConvertToBigUint, LoansRateProvider, PriceFeeder};
+use pallet_traits::{
+    ConvertToBigUint, LoansMarketDataProvider, LoansOperator, LoansPositionDataProvider,
+    LoansRateProvider, MarketInfo, MarketStatus, PriceFeeder,
+};
 use primitives::{Balance, CurrencyId, Liquidity, Price, Rate, Ratio, Shortfall, Timestamp};
 use sp_runtime::{
     traits::{
@@ -76,6 +79,7 @@ pub const MIN_INTEREST_CALCULATING_INTERVAL: u64 = 100; // 100 seconds
 pub const MAX_EXCHANGE_RATE: u128 = 1_000_000_000_000_000_000; // 1
 pub const MIN_EXCHANGE_RATE: u128 = 20_000_000_000_000_000; // 0.02
 
+type AccountIdOf<T> = <T as frame_system::Config>::AccountId;
 type AssetIdOf<T> =
     <<T as Config>::Assets as Inspect<<T as frame_system::Config>::AccountId>>::AssetId;
 type BalanceOf<T> =
@@ -2024,5 +2028,66 @@ impl<T: Config> LoansRateProvider<AssetIdOf<T>> for Pallet<T> {
             return rate;
         }
         None
+    }
+}
+
+#[allow(unused_variables)]
+impl<T: Config> LoansOperator<AssetIdOf<T>, AccountIdOf<T>, BalanceOf<T>> for Pallet<T> {
+    fn do_mint(
+        supplier: &AccountIdOf<T>,
+        asset_id: &AssetIdOf<T>,
+        amount: BalanceOf<T>,
+    ) -> Result<(), DispatchError> {
+        Ok(())
+    }
+    fn do_borrow(
+        borrower: &AccountIdOf<T>,
+        asset_id: &AssetIdOf<T>,
+        amount: BalanceOf<T>,
+    ) -> Result<(), DispatchError> {
+        Ok(())
+    }
+    fn do_collateral_asset(
+        supplier: &AccountIdOf<T>,
+        asset_id: &AssetIdOf<T>,
+        enable: bool,
+    ) -> Result<(), DispatchError> {
+        Ok(())
+    }
+    fn do_repay_borrow(
+        borrower: &AccountIdOf<T>,
+        asset_id: &AssetIdOf<T>,
+        amount: BalanceOf<T>,
+    ) -> Result<(), DispatchError> {
+        Ok(())
+    }
+    fn do_redeem(
+        supplier: &AccountIdOf<T>,
+        asset_id: &AssetIdOf<T>,
+        amount: BalanceOf<T>,
+    ) -> Result<(), DispatchError> {
+        Ok(())
+    }
+}
+
+#[allow(unused_variables)]
+impl<T: Config> LoansMarketDataProvider<AssetIdOf<T>, BalanceOf<T>> for Pallet<T> {
+    fn get_market_info(asset_id: &AssetIdOf<T>) -> Result<MarketInfo, DispatchError> {
+        Ok(Default::default())
+    }
+    fn get_market_status(asset_id: &AssetIdOf<T>) -> Result<MarketStatus<Balance>, DispatchError> {
+        Ok(Default::default())
+    }
+}
+
+#[allow(unused_variables)]
+impl<T: Config> LoansPositionDataProvider<AssetIdOf<T>, AccountIdOf<T>, BalanceOf<T>>
+    for Pallet<T>
+{
+    fn get_current_borrow_balance(
+        asset_id: &AssetIdOf<T>,
+        borrower: &AccountIdOf<T>,
+    ) -> Result<BalanceOf<T>, DispatchError> {
+        Ok(BalanceOf::<T>::zero())
     }
 }

--- a/pallets/loans/src/lib.rs
+++ b/pallets/loans/src/lib.rs
@@ -2115,8 +2115,15 @@ impl<T: Config> LoansPositionDataProvider<AssetIdOf<T>, AccountIdOf<T>, BalanceO
     for Pallet<T>
 {
     fn get_current_borrow_balance(
-        asset_id: AssetIdOf<T>,
         borrower: &AccountIdOf<T>,
+        asset_id: AssetIdOf<T>,
+    ) -> Result<BalanceOf<T>, DispatchError> {
+        Ok(BalanceOf::<T>::zero())
+    }
+
+    fn get_current_collateral_balance(
+        supplier: &AccountIdOf<T>,
+        asset_id: AssetIdOf<T>,
     ) -> Result<BalanceOf<T>, DispatchError> {
         Ok(BalanceOf::<T>::zero())
     }

--- a/pallets/loans/src/lib.rs
+++ b/pallets/loans/src/lib.rs
@@ -814,36 +814,8 @@ pub mod pallet {
             #[pallet::compact] mint_amount: BalanceOf<T>,
         ) -> DispatchResultWithPostInfo {
             let who = ensure_signed(origin)?;
-            ensure!(!mint_amount.is_zero(), Error::<T>::InvalidAmount);
-            Self::ensure_active_market(asset_id)?;
-            Self::ensure_under_supply_cap(asset_id, mint_amount)?;
 
-            Self::accrue_interest(asset_id)?;
-
-            // update supply index before modify supply balance.
-            Self::update_reward_supply_index(asset_id)?;
-            Self::distribute_supplier_reward(asset_id, &who)?;
-
-            let exchange_rate = Self::exchange_rate_stored(asset_id)?;
-            Self::update_earned_stored(&who, asset_id, exchange_rate)?;
-            let voucher_amount = Self::calc_collateral_amount(mint_amount, exchange_rate)?;
-            ensure!(!voucher_amount.is_zero(), Error::<T>::InvalidExchangeRate);
-
-            T::Assets::transfer(asset_id, &who, &Self::account_id(), mint_amount, false)?;
-            AccountDeposits::<T>::try_mutate(asset_id, &who, |deposits| -> DispatchResult {
-                deposits.voucher_balance = deposits
-                    .voucher_balance
-                    .checked_add(voucher_amount)
-                    .ok_or(ArithmeticError::Overflow)?;
-                Ok(())
-            })?;
-            TotalSupply::<T>::try_mutate(asset_id, |total_balance| -> DispatchResult {
-                let new_balance = total_balance
-                    .checked_add(voucher_amount)
-                    .ok_or(ArithmeticError::Overflow)?;
-                *total_balance = new_balance;
-                Ok(())
-            })?;
+            Self::do_mint(&who, asset_id, mint_amount)?;
 
             Self::deposit_event(Event::<T>::Deposited(who, asset_id, mint_amount));
 
@@ -861,14 +833,10 @@ pub mod pallet {
             asset_id: AssetIdOf<T>,
             #[pallet::compact] redeem_amount: BalanceOf<T>,
         ) -> DispatchResultWithPostInfo {
-            ensure!(!redeem_amount.is_zero(), Error::<T>::InvalidAmount);
             let who = ensure_signed(origin)?;
-            Self::ensure_active_market(asset_id)?;
-            Self::accrue_interest(asset_id)?;
-            let exchange_rate = Self::exchange_rate_stored(asset_id)?;
-            Self::update_earned_stored(&who, asset_id, exchange_rate)?;
-            let voucher_amount = Self::calc_collateral_amount(redeem_amount, exchange_rate)?;
-            let redeem_amount = Self::do_redeem(&who, asset_id, voucher_amount)?;
+            ensure!(!redeem_amount.is_zero(), Error::<T>::InvalidAmount);
+            let redeem_amount = Self::do_redeem(&who, asset_id, redeem_amount)?;
+
             Self::deposit_event(Event::<T>::Redeemed(who, asset_id, redeem_amount));
 
             Ok(().into())
@@ -889,7 +857,7 @@ pub mod pallet {
             let exchange_rate = Self::exchange_rate_stored(asset_id)?;
             Self::update_earned_stored(&who, asset_id, exchange_rate)?;
             let deposits = AccountDeposits::<T>::get(asset_id, &who);
-            let redeem_amount = Self::do_redeem(&who, asset_id, deposits.voucher_balance)?;
+            let redeem_amount = Self::do_redeem_voucher(&who, asset_id, deposits.voucher_balance)?;
             Self::deposit_event(Event::<T>::Redeemed(who, asset_id, redeem_amount));
 
             Ok(().into())
@@ -907,33 +875,8 @@ pub mod pallet {
             #[pallet::compact] borrow_amount: BalanceOf<T>,
         ) -> DispatchResultWithPostInfo {
             let who = ensure_signed(origin)?;
-            Self::ensure_active_market(asset_id)?;
 
-            Self::accrue_interest(asset_id)?;
-            Self::borrow_allowed(asset_id, &who, borrow_amount)?;
-
-            // update borrow index after accrue interest.
-            Self::update_reward_borrow_index(asset_id)?;
-            Self::distribute_borrower_reward(asset_id, &who)?;
-
-            let account_borrows = Self::current_borrow_balance(&who, asset_id)?;
-            let account_borrows_new = account_borrows
-                .checked_add(borrow_amount)
-                .ok_or(ArithmeticError::Overflow)?;
-            let total_borrows = Self::total_borrows(asset_id);
-            let total_borrows_new = total_borrows
-                .checked_add(borrow_amount)
-                .ok_or(ArithmeticError::Overflow)?;
-            AccountBorrows::<T>::insert(
-                asset_id,
-                &who,
-                BorrowSnapshot {
-                    principal: account_borrows_new,
-                    borrow_index: Self::borrow_index(asset_id),
-                },
-            );
-            TotalBorrows::<T>::insert(asset_id, total_borrows_new);
-            T::Assets::transfer(asset_id, &Self::account_id(), &who, borrow_amount, false)?;
+            Self::do_borrow(&who, asset_id, borrow_amount)?;
 
             Self::deposit_event(Event::<T>::Borrowed(who, asset_id, borrow_amount));
 
@@ -952,10 +895,8 @@ pub mod pallet {
             #[pallet::compact] repay_amount: BalanceOf<T>,
         ) -> DispatchResultWithPostInfo {
             let who = ensure_signed(origin)?;
-            Self::ensure_active_market(asset_id)?;
-            Self::accrue_interest(asset_id)?;
-            let account_borrows = Self::current_borrow_balance(&who, asset_id)?;
-            Self::do_repay_borrow(&who, asset_id, account_borrows, repay_amount)?;
+
+            Self::do_repay_borrow(&who, asset_id, repay_amount)?;
 
             Self::deposit_event(Event::<T>::RepaidBorrow(who, asset_id, repay_amount));
 
@@ -975,7 +916,7 @@ pub mod pallet {
             Self::ensure_active_market(asset_id)?;
             Self::accrue_interest(asset_id)?;
             let account_borrows = Self::current_borrow_balance(&who, asset_id)?;
-            Self::do_repay_borrow(&who, asset_id, account_borrows, account_borrows)?;
+            Self::do_repay_borrow(&who, asset_id, account_borrows)?;
 
             Self::deposit_event(Event::<T>::RepaidBorrow(who, asset_id, account_borrows));
 
@@ -999,40 +940,17 @@ pub mod pallet {
                 AccountDeposits::<T>::contains_key(asset_id, &who),
                 Error::<T>::NoDeposit
             );
-            let mut deposits = Self::account_deposits(asset_id, &who);
+            let deposits = Self::account_deposits(asset_id, &who);
             if deposits.is_collateral == enable {
                 return Err(Error::<T>::DuplicateOperation.into());
             }
-            // turn on the collateral button
+
+            Self::do_collateral_asset(&who, asset_id, enable)?;
             if enable {
-                deposits.is_collateral = true;
-                AccountDeposits::<T>::insert(asset_id, &who, deposits);
                 Self::deposit_event(Event::<T>::CollateralAssetAdded(who, asset_id));
-
-                return Ok(().into());
+            } else {
+                Self::deposit_event(Event::<T>::CollateralAssetRemoved(who, asset_id));
             }
-            // turn off the collateral button after checking the liquidity
-            let total_collateral_value = Self::total_collateral_value(&who)?;
-            let collateral_asset_value = Self::collateral_asset_value(&who, asset_id)?;
-            let total_borrowed_value = Self::total_borrowed_value(&who)?;
-            log::trace!(
-                target: "loans::collateral_asset",
-                "total_collateral_value: {:?}, collateral_asset_value: {:?}, total_borrowed_value: {:?}",
-                total_collateral_value.into_inner(),
-                collateral_asset_value.into_inner(),
-                total_borrowed_value.into_inner(),
-            );
-            if total_collateral_value
-                < total_borrowed_value
-                    .checked_add(&collateral_asset_value)
-                    .ok_or(ArithmeticError::Overflow)?
-            {
-                return Err(Error::<T>::InsufficientLiquidity.into());
-            }
-
-            deposits.is_collateral = false;
-            AccountDeposits::<T>::insert(asset_id, &who, deposits);
-            Self::deposit_event(Event::<T>::CollateralAssetRemoved(who, asset_id));
 
             Ok(().into())
         }
@@ -1169,7 +1087,7 @@ pub mod pallet {
             Self::ensure_active_market(asset_id)?;
             let exchange_rate = Self::exchange_rate_stored(asset_id)?;
             let voucher_amount = Self::calc_collateral_amount(redeem_amount, exchange_rate)?;
-            let redeem_amount = Self::do_redeem(&from, asset_id, voucher_amount)?;
+            let redeem_amount = Self::do_redeem_voucher(&from, asset_id, voucher_amount)?;
             T::Assets::transfer(asset_id, &from, &receiver, redeem_amount, false)?;
             Self::deposit_event(Event::<T>::IncentiveReservesReduced(
                 receiver,
@@ -1407,7 +1325,7 @@ impl<T: Config> Pallet<T> {
         let redeem_effects_value = Self::get_asset_value(asset_id, effects_amount)?;
         log::trace!(
             target: "loans::redeem_allowed",
-            "redeem_amount: {:?}, redeem_dffects_value: {:?}",
+            "redeem_amount: {:?}, redeem_effects_value: {:?}",
             redeem_amount,
             redeem_effects_value.into_inner(),
         );
@@ -1422,7 +1340,7 @@ impl<T: Config> Pallet<T> {
     }
 
     #[require_transactional]
-    pub fn do_redeem(
+    pub fn do_redeem_voucher(
         who: &T::AccountId,
         asset_id: AssetIdOf<T>,
         voucher_amount: BalanceOf<T>,
@@ -1480,7 +1398,7 @@ impl<T: Config> Pallet<T> {
     }
 
     #[require_transactional]
-    fn do_repay_borrow(
+    fn do_repay_borrow_with_amount(
         borrower: &T::AccountId,
         asset_id: AssetIdOf<T>,
         account_borrows: BalanceOf<T>,
@@ -2043,47 +1961,151 @@ impl<T: Config> LoansRateProvider<AssetIdOf<T>> for Pallet<T> {
 impl<T: Config> LoansOperator<AssetIdOf<T>, AccountIdOf<T>, BalanceOf<T>> for Pallet<T> {
     fn do_mint(
         supplier: &AccountIdOf<T>,
-        asset_id: &AssetIdOf<T>,
+        asset_id: AssetIdOf<T>,
         amount: BalanceOf<T>,
     ) -> Result<(), DispatchError> {
+        ensure!(!amount.is_zero(), Error::<T>::InvalidAmount);
+        Self::ensure_active_market(asset_id)?;
+        Self::ensure_under_supply_cap(asset_id, amount)?;
+
+        Self::accrue_interest(asset_id)?;
+
+        // update supply index before modify supply balance.
+        Self::update_reward_supply_index(asset_id)?;
+        Self::distribute_supplier_reward(asset_id, supplier)?;
+
+        let exchange_rate = Self::exchange_rate_stored(asset_id)?;
+        Self::update_earned_stored(supplier, asset_id, exchange_rate)?;
+        let voucher_amount = Self::calc_collateral_amount(amount, exchange_rate)?;
+        ensure!(!voucher_amount.is_zero(), Error::<T>::InvalidExchangeRate);
+
+        T::Assets::transfer(asset_id, supplier, &Self::account_id(), amount, false)?;
+        AccountDeposits::<T>::try_mutate(asset_id, supplier, |deposits| -> DispatchResult {
+            deposits.voucher_balance = deposits
+                .voucher_balance
+                .checked_add(voucher_amount)
+                .ok_or(ArithmeticError::Overflow)?;
+            Ok(())
+        })?;
+        TotalSupply::<T>::try_mutate(asset_id, |total_balance| -> DispatchResult {
+            let new_balance = total_balance
+                .checked_add(voucher_amount)
+                .ok_or(ArithmeticError::Overflow)?;
+            *total_balance = new_balance;
+            Ok(())
+        })?;
         Ok(())
     }
+
     fn do_borrow(
         borrower: &AccountIdOf<T>,
-        asset_id: &AssetIdOf<T>,
+        asset_id: AssetIdOf<T>,
         amount: BalanceOf<T>,
     ) -> Result<(), DispatchError> {
+        Self::ensure_active_market(asset_id)?;
+
+        Self::accrue_interest(asset_id)?;
+        Self::borrow_allowed(asset_id, borrower, amount)?;
+
+        // update borrow index after accrue interest.
+        Self::update_reward_borrow_index(asset_id)?;
+        Self::distribute_borrower_reward(asset_id, borrower)?;
+
+        let account_borrows = Self::current_borrow_balance(borrower, asset_id)?;
+        let account_borrows_new = account_borrows
+            .checked_add(amount)
+            .ok_or(ArithmeticError::Overflow)?;
+        let total_borrows = Self::total_borrows(asset_id);
+        let total_borrows_new = total_borrows
+            .checked_add(amount)
+            .ok_or(ArithmeticError::Overflow)?;
+        AccountBorrows::<T>::insert(
+            asset_id,
+            borrower,
+            BorrowSnapshot {
+                principal: account_borrows_new,
+                borrow_index: Self::borrow_index(asset_id),
+            },
+        );
+        TotalBorrows::<T>::insert(asset_id, total_borrows_new);
+        T::Assets::transfer(asset_id, &Self::account_id(), borrower, amount, false)?;
+
         Ok(())
     }
+
     fn do_collateral_asset(
         supplier: &AccountIdOf<T>,
-        asset_id: &AssetIdOf<T>,
+        asset_id: AssetIdOf<T>,
         enable: bool,
     ) -> Result<(), DispatchError> {
+        Self::ensure_active_market(asset_id)?;
+        ensure!(
+            AccountDeposits::<T>::contains_key(asset_id, supplier),
+            Error::<T>::NoDeposit
+        );
+        let mut deposits = Self::account_deposits(asset_id, supplier);
+        // turn on the collateral button
+        if enable {
+            deposits.is_collateral = true;
+            AccountDeposits::<T>::insert(asset_id, supplier, deposits);
+            return Ok(());
+        }
+        // turn off the collateral button after checking the liquidity
+        let total_collateral_value = Self::total_collateral_value(supplier)?;
+        let collateral_asset_value = Self::collateral_asset_value(supplier, asset_id)?;
+        let total_borrowed_value = Self::total_borrowed_value(supplier)?;
+        log::trace!(
+            target: "loans::collateral_asset",
+            "total_collateral_value: {:?}, collateral_asset_value: {:?}, total_borrowed_value: {:?}",
+            total_collateral_value.into_inner(),
+            collateral_asset_value.into_inner(),
+            total_borrowed_value.into_inner(),
+        );
+        if total_collateral_value
+            < total_borrowed_value
+                .checked_add(&collateral_asset_value)
+                .ok_or(ArithmeticError::Overflow)?
+        {
+            return Err(Error::<T>::InsufficientLiquidity.into());
+        }
+        deposits.is_collateral = false;
+        AccountDeposits::<T>::insert(asset_id, supplier, deposits);
         Ok(())
     }
+
     fn do_repay_borrow(
         borrower: &AccountIdOf<T>,
-        asset_id: &AssetIdOf<T>,
+        asset_id: AssetIdOf<T>,
         amount: BalanceOf<T>,
     ) -> Result<(), DispatchError> {
+        Self::ensure_active_market(asset_id)?;
+        Self::accrue_interest(asset_id)?;
+        let account_borrows = Self::current_borrow_balance(borrower, asset_id)?;
+        Self::do_repay_borrow_with_amount(borrower, asset_id, account_borrows, amount)?;
         Ok(())
     }
+
     fn do_redeem(
         supplier: &AccountIdOf<T>,
-        asset_id: &AssetIdOf<T>,
+        asset_id: AssetIdOf<T>,
         amount: BalanceOf<T>,
-    ) -> Result<(), DispatchError> {
-        Ok(())
+    ) -> Result<BalanceOf<T>, DispatchError> {
+        Self::ensure_active_market(asset_id)?;
+        Self::accrue_interest(asset_id)?;
+        let exchange_rate = Self::exchange_rate_stored(asset_id)?;
+        Self::update_earned_stored(supplier, asset_id, exchange_rate)?;
+        let voucher_amount = Self::calc_collateral_amount(amount, exchange_rate)?;
+        let redeem_amount = Self::do_redeem_voucher(supplier, asset_id, voucher_amount)?;
+        Ok(redeem_amount)
     }
 }
 
 #[allow(unused_variables)]
 impl<T: Config> LoansMarketDataProvider<AssetIdOf<T>, BalanceOf<T>> for Pallet<T> {
-    fn get_market_info(asset_id: &AssetIdOf<T>) -> Result<MarketInfo, DispatchError> {
+    fn get_market_info(asset_id: AssetIdOf<T>) -> Result<MarketInfo, DispatchError> {
         Ok(Default::default())
     }
-    fn get_market_status(asset_id: &AssetIdOf<T>) -> Result<MarketStatus<Balance>, DispatchError> {
+    fn get_market_status(asset_id: AssetIdOf<T>) -> Result<MarketStatus<Balance>, DispatchError> {
         Ok(Default::default())
     }
 }
@@ -2093,7 +2115,7 @@ impl<T: Config> LoansPositionDataProvider<AssetIdOf<T>, AccountIdOf<T>, BalanceO
     for Pallet<T>
 {
     fn get_current_borrow_balance(
-        asset_id: &AssetIdOf<T>,
+        asset_id: AssetIdOf<T>,
         borrower: &AccountIdOf<T>,
     ) -> Result<BalanceOf<T>, DispatchError> {
         Ok(BalanceOf::<T>::zero())

--- a/pallets/loans/src/lib.rs
+++ b/pallets/loans/src/lib.rs
@@ -1225,13 +1225,13 @@ impl<T: Config> Pallet<T> {
     }
 
     fn current_collateral_balance(
-        borrower: &T::AccountId,
+        supplier: &T::AccountId,
         asset_id: AssetIdOf<T>,
     ) -> Result<BalanceOf<T>, DispatchError> {
-        if !AccountDeposits::<T>::contains_key(asset_id, borrower) {
+        if !AccountDeposits::<T>::contains_key(asset_id, supplier) {
             return Ok(BalanceOf::<T>::zero());
         }
-        let deposits = Self::account_deposits(asset_id, borrower);
+        let deposits = Self::account_deposits(asset_id, supplier);
         if !deposits.is_collateral {
             return Ok(BalanceOf::<T>::zero());
         }
@@ -1248,10 +1248,10 @@ impl<T: Config> Pallet<T> {
     }
 
     fn collateral_asset_value(
-        borrower: &T::AccountId,
+        supplier: &T::AccountId,
         asset_id: AssetIdOf<T>,
     ) -> Result<FixedU128, DispatchError> {
-        let effects_amount = Self::current_collateral_balance(borrower, asset_id)?;
+        let effects_amount = Self::current_collateral_balance(supplier, asset_id)?;
 
         Self::get_asset_value(asset_id, effects_amount)
     }
@@ -1279,11 +1279,11 @@ impl<T: Config> Pallet<T> {
         Self::get_asset_value(asset_id, effects_amount)
     }
 
-    fn total_collateral_value(borrower: &T::AccountId) -> Result<FixedU128, DispatchError> {
+    fn total_collateral_value(supplier: &T::AccountId) -> Result<FixedU128, DispatchError> {
         let mut total_asset_value: FixedU128 = FixedU128::zero();
         for (asset_id, _market) in Self::active_markets() {
             total_asset_value = total_asset_value
-                .checked_add(&Self::collateral_asset_value(borrower, asset_id)?)
+                .checked_add(&Self::collateral_asset_value(supplier, asset_id)?)
                 .ok_or(ArithmeticError::Overflow)?;
         }
 

--- a/pallets/loans/src/mock.rs
+++ b/pallets/loans/src/mock.rs
@@ -198,9 +198,19 @@ impl VaultTokenCurrenciesFilter<CurrencyId> for TokenCurrenciesFilter {
 }
 
 pub struct VaultLoansRateProvider;
-impl LoansRateProvider<CurrencyId> for VaultLoansRateProvider {
-    fn get_full_interest_rate(_asset_id: &CurrencyId) -> Option<Rate> {
+impl LoansMarketDataProvider<CurrencyId, Balance> for VaultLoansRateProvider {
+    fn get_full_interest_rate(_asset_id: CurrencyId) -> Option<Rate> {
         Some(Rate::from_inner(450_000_000_000_000_000))
+    }
+
+    fn get_market_info(_: CurrencyId) -> Result<MarketInfo, sp_runtime::DispatchError> {
+        Ok(Default::default())
+    }
+
+    fn get_market_status(
+        _: CurrencyId,
+    ) -> Result<MarketStatus<Balance>, sp_runtime::DispatchError> {
+        Ok(Default::default())
     }
 }
 

--- a/pallets/loans/src/tests.rs
+++ b/pallets/loans/src/tests.rs
@@ -29,6 +29,8 @@ use sp_runtime::{
 
 use mock::*;
 
+use crate::mock::Loans;
+
 #[test]
 fn init_minting_ok() {
     new_test_ext().execute_with(|| {

--- a/pallets/loans/src/tests/edge_cases.rs
+++ b/pallets/loans/src/tests/edge_cases.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::tests::Loans;
 use crate::{mock::*, Error};
 use frame_support::{assert_err, assert_ok};
 use sp_runtime::FixedPointNumber;

--- a/pallets/loans/src/tests/interest_rate.rs
+++ b/pallets/loans/src/tests/interest_rate.rs
@@ -1,3 +1,4 @@
+use crate::tests::Loans;
 use crate::{mock::*, Markets};
 use frame_support::assert_ok;
 use primitives::{Rate, Ratio, SECONDS_PER_YEAR};

--- a/pallets/prices/src/lib.rs
+++ b/pallets/prices/src/lib.rs
@@ -85,7 +85,7 @@ pub mod pallet {
         type VaultTokenExchangeRateProvider: VaultTokenExchangeRateProvider<CurrencyId>;
 
         /// The provider of Loans rate for vault_token
-        type VaultLoansRateProvider: LoansRateProvider<CurrencyId>;
+        type VaultLoansRateProvider: LoansMarketDataProvider<CurrencyId, BalanceOf<Self>>;
 
         /// Specify all the AMMs we are routing between
         type AMM: AMM<AccountIdOf<Self>, AssetIdOf<Self>, BalanceOf<Self>, Self::BlockNumber>;
@@ -229,7 +229,7 @@ impl<T: Config> Pallet<T> {
         base_price: TimeStampedPrice,
     ) -> Option<TimeStampedPrice> {
         if T::VaultTokenCurrenciesFilter::contains(asset_id) {
-            return T::VaultLoansRateProvider::get_full_interest_rate(asset_id).and_then(
+            return T::VaultLoansRateProvider::get_full_interest_rate(*asset_id).and_then(
                 |implied_yield_rate| {
                     T::VaultTokenExchangeRateProvider::get_exchange_rate(
                         asset_id,

--- a/pallets/prices/src/mock.rs
+++ b/pallets/prices/src/mock.rs
@@ -158,9 +158,18 @@ impl VaultTokenCurrenciesFilter<CurrencyId> for TokenCurrenciesFilter {
 }
 
 pub struct VaultLoansRateProvider;
-impl LoansRateProvider<CurrencyId> for VaultLoansRateProvider {
-    fn get_full_interest_rate(_asset_id: &CurrencyId) -> Option<Rate> {
+impl LoansMarketDataProvider<CurrencyId, Balance> for VaultLoansRateProvider {
+    fn get_full_interest_rate(_asset_id: CurrencyId) -> Option<Rate> {
         Some(Rate::from_inner(450_000_000_000_000_000))
+    }
+
+    fn get_market_info(_: CurrencyId) -> Result<MarketInfo, sp_runtime::DispatchError> {
+        Ok(Default::default())
+    }
+    fn get_market_status(
+        _: CurrencyId,
+    ) -> Result<MarketStatus<Balance>, sp_runtime::DispatchError> {
+        Ok(Default::default())
     }
 }
 

--- a/pallets/traits/src/lib.rs
+++ b/pallets/traits/src/lib.rs
@@ -10,8 +10,10 @@ use sp_std::prelude::*;
 
 use primitives::{CurrencyId, DerivativeIndex, PersistedValidationData, PriceDetail, Rate};
 
+pub mod loans;
 pub mod ump;
 pub mod xcm;
+pub use loans::*;
 
 pub trait EmergencyCallFilter<Call> {
     fn contains(call: &Call) -> bool;
@@ -220,8 +222,4 @@ pub trait DistributionStrategy<Balance> {
         unbonding_amounts: Vec<(DerivativeIndex, Balance)>,
         input: Balance,
     ) -> Vec<(DerivativeIndex, Balance)>;
-}
-
-pub trait LoansRateProvider<CurrencyId> {
-    fn get_full_interest_rate(asset_id: &CurrencyId) -> Option<Rate>;
 }

--- a/pallets/traits/src/loans.rs
+++ b/pallets/traits/src/loans.rs
@@ -19,11 +19,7 @@ use scale_info::TypeInfo;
 use sp_runtime::{FixedU128, RuntimeDebug};
 use sp_std::prelude::*;
 
-pub trait LoansRateProvider<CurrencyId> {
-    fn get_full_interest_rate(asset_id: &CurrencyId) -> Option<Rate>;
-}
-
-pub trait LoansOperator<CurrencyId, AccountId, Balance> {
+pub trait Loans<CurrencyId, AccountId, Balance> {
     fn do_mint(
         supplier: &AccountId,
         asset_id: CurrencyId,
@@ -63,13 +59,17 @@ pub trait LoansPositionDataProvider<CurrencyId, AccountId, Balance> {
     ) -> Result<Balance, DispatchError>;
 }
 
+/// MarketInfo contains some static attrs as a subset of Market struct in Loans
 #[derive(Default, Copy, Clone, Encode, Decode, RuntimeDebug, TypeInfo)]
 pub struct MarketInfo {
     pub collateral_factor: Ratio,
+    pub liquidation_threshold: Ratio,
+    pub reserve_factor: Ratio,
+    pub close_factor: Ratio,
     pub full_rate: Rate,
 }
 
-/// MarketStatus
+/// MarketStatus contains some dynamic calculated attrs of Market
 #[derive(Default, Copy, Clone, Encode, Decode, RuntimeDebug, TypeInfo)]
 pub struct MarketStatus<Balance> {
     pub borrow_rate: Rate,
@@ -84,4 +84,6 @@ pub struct MarketStatus<Balance> {
 pub trait LoansMarketDataProvider<CurrencyId, Balance> {
     fn get_market_info(asset_id: CurrencyId) -> Result<MarketInfo, DispatchError>;
     fn get_market_status(asset_id: CurrencyId) -> Result<MarketStatus<Balance>, DispatchError>;
+    // for compatibility we keep this func
+    fn get_full_interest_rate(asset_id: CurrencyId) -> Option<Rate>;
 }

--- a/pallets/traits/src/loans.rs
+++ b/pallets/traits/src/loans.rs
@@ -26,34 +26,34 @@ pub trait LoansRateProvider<CurrencyId> {
 pub trait LoansOperator<CurrencyId, AccountId, Balance> {
     fn do_mint(
         supplier: &AccountId,
-        asset_id: &CurrencyId,
+        asset_id: CurrencyId,
         amount: Balance,
     ) -> Result<(), DispatchError>;
     fn do_borrow(
         borrower: &AccountId,
-        asset_id: &CurrencyId,
+        asset_id: CurrencyId,
         amount: Balance,
     ) -> Result<(), DispatchError>;
     fn do_collateral_asset(
         supplier: &AccountId,
-        asset_id: &CurrencyId,
+        asset_id: CurrencyId,
         enable: bool,
     ) -> Result<(), DispatchError>;
     fn do_repay_borrow(
         borrower: &AccountId,
-        asset_id: &CurrencyId,
+        asset_id: CurrencyId,
         amount: Balance,
     ) -> Result<(), DispatchError>;
     fn do_redeem(
         supplier: &AccountId,
-        asset_id: &CurrencyId,
+        asset_id: CurrencyId,
         amount: Balance,
-    ) -> Result<(), DispatchError>;
+    ) -> Result<Balance, DispatchError>;
 }
 
 pub trait LoansPositionDataProvider<CurrencyId, AccountId, Balance> {
     fn get_current_borrow_balance(
-        asset_id: &CurrencyId,
+        asset_id: CurrencyId,
         borrower: &AccountId,
     ) -> Result<Balance, DispatchError>;
 }
@@ -77,6 +77,6 @@ pub struct MarketStatus<Balance> {
 }
 
 pub trait LoansMarketDataProvider<CurrencyId, Balance> {
-    fn get_market_info(asset_id: &CurrencyId) -> Result<MarketInfo, DispatchError>;
-    fn get_market_status(asset_id: &CurrencyId) -> Result<MarketStatus<Balance>, DispatchError>;
+    fn get_market_info(asset_id: CurrencyId) -> Result<MarketInfo, DispatchError>;
+    fn get_market_status(asset_id: CurrencyId) -> Result<MarketStatus<Balance>, DispatchError>;
 }

--- a/pallets/traits/src/loans.rs
+++ b/pallets/traits/src/loans.rs
@@ -53,8 +53,13 @@ pub trait LoansOperator<CurrencyId, AccountId, Balance> {
 
 pub trait LoansPositionDataProvider<CurrencyId, AccountId, Balance> {
     fn get_current_borrow_balance(
-        asset_id: CurrencyId,
         borrower: &AccountId,
+        asset_id: CurrencyId,
+    ) -> Result<Balance, DispatchError>;
+
+    fn get_current_collateral_balance(
+        supplier: &AccountId,
+        asset_id: CurrencyId,
     ) -> Result<Balance, DispatchError>;
 }
 

--- a/pallets/traits/src/loans.rs
+++ b/pallets/traits/src/loans.rs
@@ -1,0 +1,82 @@
+// Copyright 2021 Parallel Finance Developer.
+// This file is part of Parallel Finance.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use codec::{Decode, Encode};
+use frame_support::dispatch::DispatchError;
+use primitives::{Rate, Ratio};
+use scale_info::TypeInfo;
+use sp_runtime::{FixedU128, RuntimeDebug};
+use sp_std::prelude::*;
+
+pub trait LoansRateProvider<CurrencyId> {
+    fn get_full_interest_rate(asset_id: &CurrencyId) -> Option<Rate>;
+}
+
+pub trait LoansOperator<CurrencyId, AccountId, Balance> {
+    fn do_mint(
+        supplier: &AccountId,
+        asset_id: &CurrencyId,
+        amount: Balance,
+    ) -> Result<(), DispatchError>;
+    fn do_borrow(
+        borrower: &AccountId,
+        asset_id: &CurrencyId,
+        amount: Balance,
+    ) -> Result<(), DispatchError>;
+    fn do_collateral_asset(
+        supplier: &AccountId,
+        asset_id: &CurrencyId,
+        enable: bool,
+    ) -> Result<(), DispatchError>;
+    fn do_repay_borrow(
+        borrower: &AccountId,
+        asset_id: &CurrencyId,
+        amount: Balance,
+    ) -> Result<(), DispatchError>;
+    fn do_redeem(
+        supplier: &AccountId,
+        asset_id: &CurrencyId,
+        amount: Balance,
+    ) -> Result<(), DispatchError>;
+}
+
+pub trait LoansPositionDataProvider<CurrencyId, AccountId, Balance> {
+    fn get_current_borrow_balance(
+        asset_id: &CurrencyId,
+        borrower: &AccountId,
+    ) -> Result<Balance, DispatchError>;
+}
+
+#[derive(Default, Copy, Clone, Encode, Decode, RuntimeDebug, TypeInfo)]
+pub struct MarketInfo {
+    pub collateral_factor: Ratio,
+    pub full_rate: Rate,
+}
+
+/// MarketStatus
+#[derive(Default, Copy, Clone, Encode, Decode, RuntimeDebug, TypeInfo)]
+pub struct MarketStatus<Balance> {
+    pub borrow_rate: Rate,
+    pub supply_rate: Rate,
+    pub exchange_rate: Rate,
+    pub utilization: Ratio,
+    pub total_borrows: Balance,
+    pub total_reserves: Balance,
+    pub borrow_index: FixedU128,
+}
+
+pub trait LoansMarketDataProvider<CurrencyId, Balance> {
+    fn get_market_info(asset_id: &CurrencyId) -> Result<MarketInfo, DispatchError>;
+    fn get_market_status(asset_id: &CurrencyId) -> Result<MarketStatus<Balance>, DispatchError>;
+}


### PR DESCRIPTION
Original design from @GopherJ  

```
trait Loans {
    fn do_mint(supplier, asset_id, amount)
    fn do_borrow(borrower, asset_id, amount)
    fn do_collateral_asset(supplier, asset_id, enable: bool) => LS will need to handle DuplicatedOperation error
    fn do_repay_borrow(borrower, asset_id, amount)
    fn do_redeem(supplier, asset_id, amount)
}

trait LoansPositionDataProvider {
    fn get_current_borrow_balance(borrower, asset_id)
}

trait LoansMarketDataProvider {
    fn get_market_status(asset_id) // need to add collateral_factor or add a new member function
}
```