### PR TITLE
Lf liquidate threshold

### DIFF
--- a/pallets/loans/rpc/runtime-api/src/lib.rs
+++ b/pallets/loans/rpc/runtime-api/src/lib.rs
@@ -22,8 +22,8 @@ sp_api::decl_runtime_apis! {
     pub trait LoansApi<AccountId, Balance> where
         AccountId: Codec,
         Balance: Codec {
-        fn get_account_liquidity(account: AccountId) -> Result<(Liquidity, Shortfall), DispatchError>;
+        fn get_account_liquidity(account: AccountId) -> Result<(Liquidity, Shortfall, Liquidity, Shortfall), DispatchError>;
         fn get_market_status(asset_id: CurrencyId) -> Result<(Rate, Rate, Rate, Ratio, Balance, Balance, FixedU128), DispatchError>;
-        fn get_liquidation_threshold_liquidity(account: AccountId) -> Result<(Liquidity, Shortfall, FixedU128), DispatchError>;
+        fn get_liquidation_threshold_liquidity(account: AccountId) -> Result<(Liquidity, Shortfall, Liquidity, Shortfall), DispatchError>;
     }
 }

--- a/pallets/loans/rpc/src/lib.rs
+++ b/pallets/loans/rpc/src/lib.rs
@@ -38,7 +38,7 @@ where
         &self,
         account: AccountId,
         at: Option<BlockHash>,
-    ) -> RpcResult<(Liquidity, Shortfall)>;
+    ) -> RpcResult<(Liquidity, Shortfall, Liquidity, Shortfall)>;
     #[method(name = "loans_getMarketStatus")]
     fn get_market_status(
         &self,
@@ -50,7 +50,7 @@ where
         &self,
         account: AccountId,
         at: Option<BlockHash>,
-    ) -> RpcResult<(Liquidity, Shortfall, FixedU128)>;
+    ) -> RpcResult<(Liquidity, Shortfall, Liquidity, Shortfall)>;
 }
 
 /// A struct that implements the [`LoansApi`].
@@ -101,7 +101,7 @@ where
         &self,
         account: AccountId,
         at: Option<<Block as BlockT>::Hash>,
-    ) -> RpcResult<(Liquidity, Shortfall)> {
+    ) -> RpcResult<(Liquidity, Shortfall, Liquidity, Shortfall)> {
         let api = self.client.runtime_api();
         let at = BlockId::hash(at.unwrap_or(
             // If the block hash is not supplied assume the best block.
@@ -149,7 +149,7 @@ where
         &self,
         account: AccountId,
         at: Option<<Block as BlockT>::Hash>,
-    ) -> RpcResult<(Liquidity, Shortfall, FixedU128)> {
+    ) -> RpcResult<(Liquidity, Shortfall, Liquidity, Shortfall)> {
         let api = self.client.runtime_api();
         let at = BlockId::hash(at.unwrap_or(
             // If the block hash is not supplied assume the best block.

--- a/pallets/loans/src/lib.rs
+++ b/pallets/loans/src/lib.rs
@@ -1240,6 +1240,7 @@ impl<T: Config> Pallet<T> {
     ) -> Result<(Liquidity, Shortfall, Liquidity, Shortfall), DispatchError> {
         let total_borrow_value = Self::total_borrowed_value(account)?;
         let total_collateral_value = Self::total_liquidation_threshold_value(account)?;
+
         let lf_borrowed_value = Self::get_lf_borrowed_value(account)?;
         let lf_base_position = Self::get_lf_liquidation_base_position(account)?;
 

--- a/pallets/loans/src/lib.rs
+++ b/pallets/loans/src/lib.rs
@@ -1121,7 +1121,16 @@ impl<T: Config> Pallet<T> {
         T::PalletId::get().into_account()
     }
 
-    fn get_base_position(account: &T::AccountId) -> Result<FixedU128, DispatchError> {
+    fn get_lf_borrowed_value(account: &T::AccountId) -> Result<FixedU128, DispatchError> {
+        let lf_borrowed_amount =
+            Self::current_borrow_balance(account, T::LiquidationFreeAssetId::get())?;
+        Ok(Self::get_asset_value(
+            T::LiquidationFreeAssetId::get(),
+            lf_borrowed_amount,
+        )?)
+    }
+
+    fn get_lf_base_position(account: &T::AccountId) -> Result<FixedU128, DispatchError> {
         let mut total_asset_value: FixedU128 = FixedU128::zero();
         for (asset_id, _market) in Self::active_markets()
             .filter(|(asset_id, _)| Self::liquidation_free_collaterals().contains(asset_id))
@@ -1133,26 +1142,61 @@ impl<T: Config> Pallet<T> {
         Ok(total_asset_value)
     }
 
-    fn get_account_lf_liquidity(account: &T::AccountId) -> Result<Liquidity, DispatchError> {
-        let lf_borrowed_amount =
-            Self::current_borrow_balance(account, T::LiquidationFreeAssetId::get())?;
-        let lf_borrowed_value =
-            Self::get_asset_value(T::LiquidationFreeAssetId::get(), lf_borrowed_amount)?;
-        let lf_base_position = Self::get_base_position(account)?;
-
-        let liquidity = if lf_base_position > lf_borrowed_value {
-            lf_base_position - lf_borrowed_value
-        } else {
-            FixedU128::zero()
-        };
-        Ok(liquidity)
+    fn get_lf_liquidation_base_position(
+        account: &T::AccountId,
+    ) -> Result<FixedU128, DispatchError> {
+        let mut total_asset_value: FixedU128 = FixedU128::zero();
+        for (asset_id, _market) in Self::active_markets()
+            .filter(|(asset_id, _)| Self::liquidation_free_collaterals().contains(asset_id))
+        {
+            total_asset_value = total_asset_value
+                .checked_add(&Self::liquidation_threshold_asset_value(account, asset_id)?)
+                .ok_or(ArithmeticError::Overflow)?;
+        }
+        Ok(total_asset_value)
     }
+
+    // pub fn get_account_lf_liquidity(account: &T::AccountId) -> Result<Liquidity, DispatchError> {
+    //     let lf_borrowed_amount =
+    //         Self::current_borrow_balance(account, T::LiquidationFreeAssetId::get())?;
+    //     let lf_borrowed_value =
+    //         Self::get_asset_value(T::LiquidationFreeAssetId::get(), lf_borrowed_amount)?;
+    //     let lf_base_position = Self::get_lf_base_position(account)?;
+    //
+    //     let liquidity = if lf_base_position > lf_borrowed_value {
+    //         lf_base_position - lf_borrowed_value
+    //     } else {
+    //         FixedU128::zero()
+    //     };
+    //     Ok(liquidity)
+    // }
+    //
+    // pub fn get_account_lf_liquidation_threshold_liquidity(
+    //     account: &T::AccountId,
+    // ) -> Result<Liquidity, DispatchError> {
+    //     let lf_borrowed_amount =
+    //         Self::current_borrow_balance(account, T::LiquidationFreeAssetId::get())?;
+    //     let lf_borrowed_value =
+    //         Self::get_asset_value(T::LiquidationFreeAssetId::get(), lf_borrowed_amount)?;
+    //     let lf_base_position = Self::get_lf_liquidation_base_position(account)?;
+    //
+    //     let liquidity = if lf_base_position > lf_borrowed_value {
+    //         lf_base_position - lf_borrowed_value
+    //     } else {
+    //         FixedU128::zero()
+    //     };
+    //     Ok(liquidity)
+    // }
 
     pub fn get_account_liquidity(
         account: &T::AccountId,
-    ) -> Result<(Liquidity, Shortfall), DispatchError> {
+    ) -> Result<(Liquidity, Shortfall, Liquidity, Shortfall), DispatchError> {
         let total_borrow_value = Self::total_borrowed_value(account)?;
         let total_collateral_value = Self::total_collateral_value(account)?;
+        let lf_borrowed_value = Self::get_lf_borrowed_value(account)?;
+        let lf_base_position = Self::get_lf_base_position(account)?;
+
+        //TODO(alan): log
         log::trace!(
             target: "loans::get_account_liquidity",
             "account: {:?}, total_borrow_value: {:?}, total_collateral_value: {:?}",
@@ -1160,52 +1204,81 @@ impl<T: Config> Pallet<T> {
             total_borrow_value.into_inner(),
             total_collateral_value.into_inner(),
         );
-        if total_collateral_value > total_borrow_value {
-            Ok((
+        match (
+            total_collateral_value > total_borrow_value,
+            lf_base_position > lf_borrowed_value,
+        ) {
+            (true, true) => Ok((
                 total_collateral_value - total_borrow_value,
                 FixedU128::zero(),
-            ))
-        } else {
-            Ok((
+                lf_base_position - lf_borrowed_value,
+                FixedU128::zero(),
+            )),
+            (true, false) => Ok((
+                total_collateral_value - total_borrow_value,
+                FixedU128::zero(),
+                FixedU128::zero(),
+                lf_borrowed_value - lf_base_position,
+            )),
+            (false, true) => Ok((
                 FixedU128::zero(),
                 total_borrow_value - total_collateral_value,
-            ))
+                lf_base_position - lf_borrowed_value,
+                FixedU128::zero(),
+            )),
+            (false, false) => Ok((
+                FixedU128::zero(),
+                total_borrow_value - total_collateral_value,
+                FixedU128::zero(),
+                lf_borrowed_value - lf_base_position,
+            )),
         }
     }
 
     pub fn get_account_liquidation_threshold_liquidity(
         account: &T::AccountId,
-    ) -> Result<(Liquidity, Shortfall, Liquidity), DispatchError> {
+    ) -> Result<(Liquidity, Shortfall, Liquidity, Shortfall), DispatchError> {
         let total_borrow_value = Self::total_borrowed_value(account)?;
         let total_collateral_value = Self::total_liquidation_threshold_value(account)?;
-
-        let lf_liquidity = Self::get_account_lf_liquidity(account)?;
+        let lf_borrowed_value = Self::get_lf_borrowed_value(account)?;
+        let lf_base_position = Self::get_lf_liquidation_base_position(account)?;
 
         log::trace!(
             target: "loans::get_account_liquidation_threshold_liquidity",
-            "account: {:?}, total_borrow_value: {:?}, total_collateral_value: {:?}, lf_liquidity: {:?}",
+            "account: {:?}, total_borrow_value: {:?}, total_collateral_value: {:?}",
             account,
             total_borrow_value.into_inner(),
             total_collateral_value.into_inner(),
-            lf_liquidity.into_inner(),
         );
 
-        let locked_liquidity = total_borrow_value
-            .checked_add(&lf_liquidity)
-            .ok_or(ArithmeticError::Overflow)?;
-
-        if total_collateral_value > locked_liquidity {
-            Ok((
-                total_collateral_value - locked_liquidity,
+        match (
+            total_collateral_value > total_borrow_value,
+            lf_base_position > lf_borrowed_value,
+        ) {
+            (true, true) => Ok((
+                total_collateral_value - total_borrow_value,
                 FixedU128::zero(),
-                lf_liquidity,
-            ))
-        } else {
-            Ok((
+                lf_base_position - lf_borrowed_value,
                 FixedU128::zero(),
-                locked_liquidity - total_collateral_value,
-                lf_liquidity,
-            ))
+            )),
+            (true, false) => Ok((
+                total_collateral_value - total_borrow_value,
+                FixedU128::zero(),
+                FixedU128::zero(),
+                lf_borrowed_value - lf_base_position,
+            )),
+            (false, true) => Ok((
+                FixedU128::zero(),
+                total_borrow_value - total_collateral_value,
+                lf_base_position - lf_borrowed_value,
+                FixedU128::zero(),
+            )),
+            (false, false) => Ok((
+                FixedU128::zero(),
+                total_borrow_value - total_collateral_value,
+                FixedU128::zero(),
+                lf_borrowed_value - lf_base_position,
+            )),
         }
     }
 
@@ -1504,7 +1577,11 @@ impl<T: Config> Pallet<T> {
             repay_amount,
             market
         );
-        let (_, shortfall, _) = Self::get_account_liquidation_threshold_liquidity(borrower)?;
+        let (_, shortfall, lf_liquidity, _) =
+            Self::get_account_liquidation_threshold_liquidity(borrower)?;
+        let shortfall = shortfall
+            .checked_add(&lf_liquidity)
+            .ok_or(ArithmeticError::Overflow)?;
         if shortfall.is_zero() {
             return Err(Error::<T>::InsufficientShortfall.into());
         }
@@ -1514,7 +1591,7 @@ impl<T: Config> Pallet<T> {
         let account_borrows_value = Self::get_asset_value(liquidation_asset_id, account_borrows)?;
         let repay_value = Self::get_asset_value(liquidation_asset_id, repay_amount)?;
         let effects_borrows_value = if liquidation_asset_id == T::LiquidationFreeAssetId::get() {
-            let base_position = Self::get_base_position(borrower)?;
+            let base_position = Self::get_lf_base_position(borrower)?;
             if account_borrows_value > base_position {
                 account_borrows_value - base_position
             } else {
@@ -1811,8 +1888,7 @@ impl<T: Config> Pallet<T> {
         reduce_amount: FixedU128,
         lf_enable: bool,
     ) -> DispatchResult {
-        let (total_liquidity, _) = Self::get_account_liquidity(account)?;
-        let lf_liquidity = Self::get_account_lf_liquidity(account)?;
+        let (total_liquidity, _, lf_liquidity, _) = Self::get_account_liquidity(account)?;
 
         if lf_enable && max(total_liquidity, lf_liquidity) >= reduce_amount {
             return Ok(());

--- a/pallets/loans/src/mock.rs
+++ b/pallets/loans/src/mock.rs
@@ -396,6 +396,10 @@ pub(crate) fn new_test_ext() -> sp_io::TestExternalities {
         Loans::add_market(Origin::root(), CDOT_6_13, market_mock(PCDOT_6_13)).unwrap();
         Loans::activate_market(Origin::root(), CDOT_6_13).unwrap();
 
+        Loans::update_liquidation_free_collateral(Origin::root(), vec![CDOT_6_13]).unwrap();
+        // Loans::mint(Origin::signed(ALICE), CDOT_6_13, unit(200)).unwrap();
+        // Loans::collateral_asset(Origin::signed(ALICE), CDOT_6_13, true).unwrap();
+
         System::set_block_number(0);
         TimestampPallet::set_timestamp(6000);
     });

--- a/pallets/loans/src/mock.rs
+++ b/pallets/loans/src/mock.rs
@@ -397,8 +397,6 @@ pub(crate) fn new_test_ext() -> sp_io::TestExternalities {
         Loans::activate_market(Origin::root(), CDOT_6_13).unwrap();
 
         Loans::update_liquidation_free_collateral(Origin::root(), vec![CDOT_6_13]).unwrap();
-        // Loans::mint(Origin::signed(ALICE), CDOT_6_13, unit(200)).unwrap();
-        // Loans::collateral_asset(Origin::signed(ALICE), CDOT_6_13, true).unwrap();
 
         System::set_block_number(0);
         TimestampPallet::set_timestamp(6000);

--- a/pallets/loans/src/ptoken.rs
+++ b/pallets/loans/src/ptoken.rs
@@ -208,7 +208,7 @@ impl<T: Config> Pallet<T> {
         let collateral_value = Self::collateral_asset_value(who, underlying_id)?;
 
         // liquidity of all assets
-        let (liquidity, _) = Self::get_account_liquidity(who)?;
+        let (liquidity, _, _, _) = Self::get_account_liquidity(who)?;
 
         if liquidity >= collateral_value {
             return Ok(voucher_balance);

--- a/pallets/loans/src/ptoken.rs
+++ b/pallets/loans/src/ptoken.rs
@@ -209,7 +209,6 @@ impl<T: Config> Pallet<T> {
 
         // liquidity of all assets
         let (liquidity, _, _, _) = Self::get_account_liquidity(who)?;
-        //TODO(alan): LF support
 
         if liquidity >= collateral_value {
             return Ok(voucher_balance);

--- a/pallets/loans/src/ptoken.rs
+++ b/pallets/loans/src/ptoken.rs
@@ -209,6 +209,7 @@ impl<T: Config> Pallet<T> {
 
         // liquidity of all assets
         let (liquidity, _, _, _) = Self::get_account_liquidity(who)?;
+        //TODO(alan): LF support
 
         if liquidity >= collateral_value {
             return Ok(voucher_balance);

--- a/pallets/loans/src/tests.rs
+++ b/pallets/loans/src/tests.rs
@@ -382,9 +382,32 @@ fn get_account_liquidity_works() {
         Loans::collateral_asset(Origin::signed(ALICE), CDOT_6_13, true).unwrap();
 
         let (liquidity, _, lf_liquidity, _) = Loans::get_account_liquidity(&ALICE).unwrap();
-        assert_eq!(liquidity, FixedU128::from_inner(unit(100)));
 
+        assert_eq!(liquidity, FixedU128::from_inner(unit(100)));
         assert_eq!(lf_liquidity, FixedU128::from_inner(unit(100)));
+    })
+}
+
+#[test]
+fn get_account_liquidation_threshold_liquidity_works() {
+    new_test_ext().execute_with(|| {
+        Loans::mint(Origin::signed(BOB), DOT, unit(200)).unwrap();
+        Loans::mint(Origin::signed(BOB), KSM, unit(200)).unwrap();
+
+        Loans::mint(Origin::signed(ALICE), CDOT_6_13, unit(200)).unwrap();
+        Loans::collateral_asset(Origin::signed(ALICE), CDOT_6_13, true).unwrap();
+
+        Loans::mint(Origin::signed(ALICE), USDT, unit(200)).unwrap();
+        Loans::collateral_asset(Origin::signed(ALICE), USDT, true).unwrap();
+
+        Loans::borrow(Origin::signed(ALICE), KSM, unit(100)).unwrap();
+        Loans::borrow(Origin::signed(ALICE), DOT, unit(100)).unwrap();
+
+        let (liquidity, _, lf_liquidity, _) =
+            Loans::get_account_liquidation_threshold_liquidity(&ALICE).unwrap();
+
+        assert_eq!(liquidity, FixedU128::from_inner(unit(20)));
+        assert_eq!(lf_liquidity, FixedU128::from_inner(unit(10)));
     })
 }
 

--- a/pallets/loans/src/tests.rs
+++ b/pallets/loans/src/tests.rs
@@ -408,6 +408,14 @@ fn get_account_liquidation_threshold_liquidity_works() {
 
         assert_eq!(liquidity, FixedU128::from_inner(unit(20)));
         assert_eq!(lf_liquidity, FixedU128::from_inner(unit(10)));
+
+        MockPriceFeeder::set_price(KSM, 2.into());
+        let (liquidity, shortfall, lf_liquidity, _) =
+            Loans::get_account_liquidation_threshold_liquidity(&ALICE).unwrap();
+
+        assert_eq!(liquidity, FixedU128::from_inner(unit(0)));
+        assert_eq!(shortfall, FixedU128::from_inner(unit(80)));
+        assert_eq!(lf_liquidity, FixedU128::from_inner(unit(10)));
     })
 }
 

--- a/pallets/loans/src/tests.rs
+++ b/pallets/loans/src/tests.rs
@@ -382,13 +382,10 @@ fn get_account_liquidity_works() {
         Loans::mint(Origin::signed(ALICE), CDOT_6_13, unit(200)).unwrap();
         Loans::collateral_asset(Origin::signed(ALICE), CDOT_6_13, true).unwrap();
 
-        let (liquidity, _) = Loans::get_account_liquidity(&ALICE).unwrap();
+        let (liquidity, _, lf_liquidity, _) = Loans::get_account_liquidity(&ALICE).unwrap();
         assert_eq!(liquidity, FixedU128::from_inner(unit(100)));
 
-        assert_eq!(
-            Loans::get_account_lf_liquidity(&ALICE).unwrap(),
-            FixedU128::from_inner(unit(100))
-        );
+        assert_eq!(lf_liquidity, FixedU128::from_inner(unit(100)));
     })
 }
 

--- a/pallets/loans/src/tests.rs
+++ b/pallets/loans/src/tests.rs
@@ -378,7 +378,6 @@ fn update_liquidation_free_collateral_works() {
 #[test]
 fn get_account_liquidity_works() {
     new_test_ext().execute_with(|| {
-        Loans::update_liquidation_free_collateral(Origin::root(), vec![CDOT_6_13]).unwrap();
         Loans::mint(Origin::signed(ALICE), CDOT_6_13, unit(200)).unwrap();
         Loans::collateral_asset(Origin::signed(ALICE), CDOT_6_13, true).unwrap();
 
@@ -392,7 +391,6 @@ fn get_account_liquidity_works() {
 #[test]
 fn lf_borrow_allowed_works() {
     new_test_ext().execute_with(|| {
-        Loans::update_liquidation_free_collateral(Origin::root(), vec![CDOT_6_13]).unwrap();
         Loans::mint(Origin::signed(ALICE), CDOT_6_13, unit(200)).unwrap();
         Loans::mint(Origin::signed(DAVE), USDT, unit(200)).unwrap();
         Loans::mint(Origin::signed(DAVE), DOT, unit(200)).unwrap();

--- a/runtime/heiko/src/lib.rs
+++ b/runtime/heiko/src/lib.rs
@@ -2232,7 +2232,7 @@ impl_runtime_apis! {
     }
 
     impl pallet_loans_rpc_runtime_api::LoansApi<Block, AccountId, Balance> for Runtime {
-        fn get_account_liquidity(account: AccountId) -> Result<(Liquidity, Shortfall), DispatchError> {
+        fn get_account_liquidity(account: AccountId) -> Result<(Liquidity, Shortfall, Liquidity, Shortfall), DispatchError> {
             Loans::get_account_liquidity(&account)
         }
 
@@ -2240,7 +2240,7 @@ impl_runtime_apis! {
             Loans::get_market_status(asset_id)
         }
 
-        fn get_liquidation_threshold_liquidity(account: AccountId) -> Result<(Liquidity, Shortfall, sp_runtime::FixedU128), DispatchError> {
+        fn get_liquidation_threshold_liquidity(account: AccountId) -> Result<(Liquidity, Shortfall, Liquidity, Shortfall), DispatchError> {
             Loans::get_account_liquidation_threshold_liquidity(&account)
         }
     }

--- a/runtime/kerria/src/lib.rs
+++ b/runtime/kerria/src/lib.rs
@@ -2221,7 +2221,7 @@ impl_runtime_apis! {
     }
 
     impl pallet_loans_rpc_runtime_api::LoansApi<Block, AccountId, Balance> for Runtime {
-        fn get_account_liquidity(account: AccountId) -> Result<(Liquidity, Shortfall), DispatchError> {
+        fn get_account_liquidity(account: AccountId) -> Result<(Liquidity, Shortfall, Liquidity, Shortfall), DispatchError> {
             Loans::get_account_liquidity(&account)
         }
 
@@ -2229,7 +2229,7 @@ impl_runtime_apis! {
             Loans::get_market_status(asset_id)
         }
 
-        fn get_liquidation_threshold_liquidity(account: AccountId) -> Result<(Liquidity, Shortfall, sp_runtime::FixedU128), DispatchError> {
+        fn get_liquidation_threshold_liquidity(account: AccountId) -> Result<(Liquidity, Shortfall, Liquidity, Shortfall), DispatchError> {
             Loans::get_account_liquidation_threshold_liquidity(&account)
         }
     }

--- a/runtime/parallel/src/lib.rs
+++ b/runtime/parallel/src/lib.rs
@@ -2233,7 +2233,7 @@ impl_runtime_apis! {
     }
 
     impl pallet_loans_rpc_runtime_api::LoansApi<Block, AccountId, Balance> for Runtime {
-        fn get_account_liquidity(account: AccountId) -> Result<(Liquidity, Shortfall), DispatchError> {
+        fn get_account_liquidity(account: AccountId) -> Result<(Liquidity, Shortfall, Liquidity, Shortfall), DispatchError> {
             Loans::get_account_liquidity(&account)
         }
 
@@ -2241,7 +2241,7 @@ impl_runtime_apis! {
             Loans::get_market_status(asset_id)
         }
 
-        fn get_liquidation_threshold_liquidity(account: AccountId) -> Result<(Liquidity, Shortfall, sp_runtime::FixedU128), DispatchError> {
+        fn get_liquidation_threshold_liquidity(account: AccountId) -> Result<(Liquidity, Shortfall, Liquidity, Shortfall), DispatchError> {
             Loans::get_account_liquidation_threshold_liquidity(&account)
         }
     }

--- a/runtime/vanilla/src/lib.rs
+++ b/runtime/vanilla/src/lib.rs
@@ -2263,7 +2263,7 @@ impl_runtime_apis! {
     }
 
     impl pallet_loans_rpc_runtime_api::LoansApi<Block, AccountId, Balance> for Runtime {
-        fn get_account_liquidity(account: AccountId) -> Result<(Liquidity, Shortfall), DispatchError> {
+        fn get_account_liquidity(account: AccountId) -> Result<(Liquidity, Shortfall, Liquidity, Shortfall), DispatchError> {
             Loans::get_account_liquidity(&account)
         }
 
@@ -2271,7 +2271,7 @@ impl_runtime_apis! {
             Loans::get_market_status(asset_id)
         }
 
-        fn get_liquidation_threshold_liquidity(account: AccountId) -> Result<(Liquidity, Shortfall, sp_runtime::FixedU128), DispatchError> {
+        fn get_liquidation_threshold_liquidity(account: AccountId) -> Result<(Liquidity, Shortfall, Liquidity, Shortfall), DispatchError> {
             Loans::get_account_liquidation_threshold_liquidity(&account)
         }
     }


### PR DESCRIPTION
Allow liquidation threshold different from the collateral factor for lf market

In former, it requires the collateral factor strictly equals to the liquidation threshold due to the calculation.