### PR TITLE
Fix: update fast_match_unstake origin

### DIFF
--- a/pallets/liquid-staking/src/benchmarking.rs
+++ b/pallets/liquid-staking/src/benchmarking.rs
@@ -405,7 +405,7 @@ benchmarks! {
         let n in 1 .. 50;
         let alice: T::AccountId = account("Sample", 100, SEED);
         initial_set_up::<T>(alice.clone());
-        LiquidStaking::<T>::stake(SystemOrigin::Signed(alice.clone()).into(), STAKE_AMOUNT).unwrap();
+        LiquidStaking::<T>::stake(SystemOrigin::Signed(alice).into(), STAKE_AMOUNT).unwrap();
 
         let mut unstaker_list: Vec<T::AccountId> = vec![];
         let fast_unstake_amount = 50_000_000_000;
@@ -422,7 +422,7 @@ benchmarks! {
             assert_eq!(FastUnstakeRequests::<T>::get(&unstaker), fast_unstake_amount);
             unstaker_list.push(unstaker);
         }
-    }: _(SystemOrigin::Signed(alice.clone()), unstaker_list)
+    }: _(SystemOrigin::Root, unstaker_list)
     verify {
         let xcm_fee = T::XcmFees::get();
         let reserve = ReserveFactor::<T>::get().mul_floor(STAKE_AMOUNT);

--- a/pallets/liquid-staking/src/lib.rs
+++ b/pallets/liquid-staking/src/lib.rs
@@ -1018,7 +1018,7 @@ pub mod pallet {
             origin: OriginFor<T>,
             unstaker_list: Vec<T::AccountId>,
         ) -> DispatchResult {
-            let _ = ensure_signed(origin)?;
+            Self::ensure_origin(origin)?;
             for unstaker in unstaker_list {
                 Self::do_fast_match_unstake(&unstaker)?;
             }

--- a/pallets/liquid-staking/src/tests.rs
+++ b/pallets/liquid-staking/src/tests.rs
@@ -1157,7 +1157,7 @@ fn test_complete_fast_match_unstake_work() {
             UnstakeProvider::MatchingPool
         ));
         assert_ok!(LiquidStaking::fast_match_unstake(
-            Origin::signed(ALICE),
+            Origin::signed(BOB),
             [BOB].to_vec(),
         ));
 
@@ -1213,7 +1213,7 @@ fn test_partial_fast_match_unstake_work() {
             UnstakeProvider::MatchingPool
         ));
         assert_ok!(LiquidStaking::fast_match_unstake(
-            Origin::signed(ALICE),
+            Origin::signed(BOB),
             [BOB, ALICE].to_vec(),
         ));
 


### PR DESCRIPTION
This PR is to keep `fast_match_unstake ` consistent with `claim_for` since they both be called by stake-client.