### PR TITLE
Fix: parallel xcm config

### DIFF
--- a/runtime/parallel/src/lib.rs
+++ b/runtime/parallel/src/lib.rs
@@ -1439,7 +1439,7 @@ impl Config for XcmConfig {
     type Call = Call;
     type XcmSender = XcmRouter;
     // How to withdraw and deposit an asset.
-    type AssetTransactor = LocalAssetTransactor;
+    type AssetTransactor = AssetTransactors;
     type OriginConverter = XcmOriginToTransactDispatchOrigin;
     type IsReserve = MultiNativeAsset<AbsoluteReserveProvider>;
     // Teleporting is disabled.


### PR DESCRIPTION
# Issue:
https://clv.subscan.io/extrinsic/0x7128df6f73a44453fc60a1a83efe6b8982baa8b46f5ded63f9576d7236108ea0?tab=xcm_transfer

# Error location:
https://github.com/parallel-finance/parallel/blob/6728c1a1bbd7e6d9017f6a4247dfd7e6a71d1aef/pallets/traits/src/xcm.rs#L463

# Reason:
### Parallel
https://github.com/parallel-finance/parallel/blob/6728c1a1bbd7e6d9017f6a4247dfd7e6a71d1aef/runtime/parallel/src/lib.rs#L1442
CLV failed
![image](https://user-images.githubusercontent.com/26266313/190133500-4a34b446-9b54-49ef-8015-5a57c83ccbb1.png)


### Heiko
https://github.com/parallel-finance/parallel/blob/6728c1a1bbd7e6d9017f6a4247dfd7e6a71d1aef/runtime/heiko/src/lib.rs#L1454
USDT works good
![image](https://user-images.githubusercontent.com/26266313/190133225-de7a3719-a6e6-41c0-bbd3-48829ce2a9b0.png)


