### PR TITLE
local test for poop&some log improvement

### DIFF
--- a/primitives/src/tokens.rs
+++ b/primitives/src/tokens.rs
@@ -46,6 +46,8 @@ pub const EQ: CurrencyId = 124;
 pub const TUR: CurrencyId = 125;
 pub const LIT: CurrencyId = 127;
 pub const CLV: CurrencyId = 130;
+//local asset from moonbeam
+pub const POOP: CurrencyId = 132;
 
 // Ethereum ecosystem
 pub const EUSDT: CurrencyId = 201;

--- a/scripts/helper/src/utils.ts
+++ b/scripts/helper/src/utils.ts
@@ -162,9 +162,7 @@ export const calcWeightPerSecond = (precision: number, price: number): number =>
   /// max_fee = (weight_per_second * weight)/WEIGHT_PER_SECOND/(10**precision) * price
   /// so weight_per_second = max_fee*WEIGHT_PER_SECOND*(10**precision)/weight/price
   const weight_per_second = (((max_fee * WEIGHT_PER_SECOND) / weight) * 10 ** precision) / price
-  /// to avoid price sharply increased later so that we charge too much
-  /// just add some soft limit here
-  return Math.min(1000 * WEIGHT_PER_SECOND, Math.floor(weight_per_second))
+  return Math.floor(weight_per_second)
 }
 
 export const getDefaultRelayChainWsUrl = (): string => {


### PR DESCRIPTION
should be fine to transfer localAsset from moonbeam

a local setup including moonbase and vanilla runtime could be referenced when frontend integration

transfer from moonbase:
`0x1e000294c1c088cc9453996779630ad3af45cb0000f44482916345000000000000000001010200952001005628194e9f9ff8bd593f490fcafd033289f393e2ba860c6c51bca39c01091b3900286bee00000000`

transfer back from vanilla:
`0x2b04087100000000008a5d784563010000000000000000c80000000000e8890423c78a00000000000000000000000001010200a10f0300f24ff3a9cf04c71dbc94d0b566f7a27b94566cac00286bee00000000 `