### PR TITLE
Chore: forbid VestedTransfer

### DIFF
--- a/runtime/heiko/src/lib.rs
+++ b/runtime/heiko/src/lib.rs
@@ -25,7 +25,7 @@ use frame_support::{
         fungibles::{InspectMetadata, Mutate},
         tokens::BalanceConversion,
         AsEnsureOriginWithArg, ChangeMembers, ConstU32, Contains, EitherOfDiverse,
-        EqualPrivilegeOnly, Everything, FindAuthor, InstanceFilter, Nothing,
+        EqualPrivilegeOnly, Everything, FindAuthor, InstanceFilter, NeverEnsureOrigin, Nothing,
     },
     weights::{
         constants::{
@@ -1646,7 +1646,7 @@ impl pallet_treasury::Config for Runtime {
     type SpendFunds = ();
     type WeightInfo = weights::pallet_treasury::WeightInfo<Runtime>;
     type MaxApprovals = MaxApprovals;
-    type SpendOrigin = frame_support::traits::NeverEnsureOrigin<Balance>;
+    type SpendOrigin = NeverEnsureOrigin<Balance>;
 }
 
 parameter_types! {
@@ -1740,7 +1740,7 @@ impl orml_vesting::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type Currency = Balances;
     type MinVestedTransfer = MinVestedTransfer;
-    type VestedTransferOrigin = EnsureSigned<AccountId>;
+    type VestedTransferOrigin = NeverEnsureOrigin<AccountId>;
     type WeightInfo = weights::orml_vesting::WeightInfo<Runtime>;
     type MaxVestingSchedules = MaxVestingSchedules;
     type BlockNumberProvider = frame_system::Pallet<Runtime>;

--- a/runtime/kerria/src/lib.rs
+++ b/runtime/kerria/src/lib.rs
@@ -25,7 +25,7 @@ use frame_support::{
         fungibles::{InspectMetadata, Mutate},
         tokens::BalanceConversion,
         AsEnsureOriginWithArg, ChangeMembers, ConstU32, Contains, EitherOfDiverse,
-        EqualPrivilegeOnly, Everything, FindAuthor, InstanceFilter, Nothing,
+        EqualPrivilegeOnly, Everything, FindAuthor, InstanceFilter, NeverEnsureOrigin, Nothing,
     },
     weights::{
         constants::{
@@ -1644,7 +1644,7 @@ impl pallet_treasury::Config for Runtime {
     type SpendFunds = ();
     type WeightInfo = pallet_treasury::weights::SubstrateWeight<Runtime>;
     type MaxApprovals = MaxApprovals;
-    type SpendOrigin = frame_support::traits::NeverEnsureOrigin<Balance>;
+    type SpendOrigin = NeverEnsureOrigin<Balance>;
 }
 
 parameter_types! {
@@ -1738,7 +1738,7 @@ impl orml_vesting::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type Currency = Balances;
     type MinVestedTransfer = MinVestedTransfer;
-    type VestedTransferOrigin = EnsureSigned<AccountId>;
+    type VestedTransferOrigin = NeverEnsureOrigin<AccountId>;
     type WeightInfo = ();
     type MaxVestingSchedules = MaxVestingSchedules;
     type BlockNumberProvider = frame_system::Pallet<Runtime>;

--- a/runtime/parallel/src/lib.rs
+++ b/runtime/parallel/src/lib.rs
@@ -26,7 +26,7 @@ use frame_support::{
         fungibles::{InspectMetadata, Mutate},
         tokens::BalanceConversion,
         AsEnsureOriginWithArg, ChangeMembers, ConstU32, Contains, EitherOfDiverse,
-        EqualPrivilegeOnly, Everything, FindAuthor, InstanceFilter, Nothing,
+        EqualPrivilegeOnly, Everything, FindAuthor, InstanceFilter, NeverEnsureOrigin, Nothing,
     },
     weights::{
         constants::{
@@ -1647,7 +1647,7 @@ impl pallet_treasury::Config for Runtime {
     type SpendFunds = ();
     type WeightInfo = weights::pallet_treasury::WeightInfo<Runtime>;
     type MaxApprovals = MaxApprovals;
-    type SpendOrigin = frame_support::traits::NeverEnsureOrigin<Balance>;
+    type SpendOrigin = NeverEnsureOrigin<Balance>;
 }
 
 parameter_types! {
@@ -1741,7 +1741,7 @@ impl orml_vesting::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type Currency = Balances;
     type MinVestedTransfer = MinVestedTransfer;
-    type VestedTransferOrigin = EnsureSigned<AccountId>;
+    type VestedTransferOrigin = NeverEnsureOrigin<AccountId>;
     type WeightInfo = weights::orml_vesting::WeightInfo<Runtime>;
     type MaxVestingSchedules = MaxVestingSchedules;
     type BlockNumberProvider = frame_system::Pallet<Runtime>;

--- a/runtime/vanilla/src/lib.rs
+++ b/runtime/vanilla/src/lib.rs
@@ -25,7 +25,7 @@ use frame_support::{
         fungibles::{InspectMetadata, Mutate},
         tokens::BalanceConversion,
         AsEnsureOriginWithArg, ChangeMembers, ConstU32, Contains, EitherOfDiverse,
-        EqualPrivilegeOnly, Everything, FindAuthor, InstanceFilter, Nothing,
+        EqualPrivilegeOnly, Everything, FindAuthor, InstanceFilter, NeverEnsureOrigin, Nothing,
     },
     weights::{
         constants::{
@@ -1675,7 +1675,7 @@ impl pallet_treasury::Config for Runtime {
     type SpendFunds = ();
     type WeightInfo = pallet_treasury::weights::SubstrateWeight<Runtime>;
     type MaxApprovals = MaxApprovals;
-    type SpendOrigin = frame_support::traits::NeverEnsureOrigin<Balance>;
+    type SpendOrigin = NeverEnsureOrigin<Balance>;
 }
 
 parameter_types! {
@@ -1769,7 +1769,7 @@ impl orml_vesting::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type Currency = Balances;
     type MinVestedTransfer = MinVestedTransfer;
-    type VestedTransferOrigin = EnsureSigned<AccountId>;
+    type VestedTransferOrigin = NeverEnsureOrigin<AccountId>;
     type WeightInfo = ();
     type MaxVestingSchedules = MaxVestingSchedules;
     type BlockNumberProvider = frame_system::Pallet<Runtime>;


### PR DESCRIPTION
Since we use 'Stream pallet' now, won't use 'Vesting pallet' anymore, so forbid VestedTransfer currently and consider removing 'Vesting' in the future.
besides there is a bug before:
 
![image](https://user-images.githubusercontent.com/26266313/231674428-2d84eccf-aaad-4515-b8e6-65ade9626601.png)
![image](https://user-images.githubusercontent.com/26266313/231908966-7ff6588e-6eb9-4a12-9169-a6291e901e5d.png)
