### PR TITLE
feat: add vaults to parallel & bump runtime version to 206

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3747,7 +3747,7 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "heiko-runtime"
-version = "2.0.5"
+version = "2.0.6"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-dmp-queue",
@@ -4472,7 +4472,7 @@ dependencies = [
 
 [[package]]
 name = "kerria-runtime"
-version = "2.0.5"
+version = "2.0.6"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-dmp-queue",
@@ -6285,7 +6285,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-amm"
-version = "2.0.5"
+version = "2.0.6"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6308,7 +6308,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-asset-registry"
-version = "2.0.5"
+version = "2.0.6"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6537,7 +6537,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-bridge"
-version = "2.0.5"
+version = "2.0.6"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6629,7 +6629,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-crowdloans"
-version = "2.0.5"
+version = "2.0.6"
 dependencies = [
  "bytes",
  "cumulus-pallet-dmp-queue",
@@ -6675,7 +6675,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-currency-adapter"
-version = "2.0.5"
+version = "2.0.6"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6759,7 +6759,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-emergency-shutdown"
-version = "2.0.5"
+version = "2.0.6"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6824,7 +6824,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-evm-precompile-assets-erc20"
-version = "2.0.5"
+version = "2.0.6"
 dependencies = [
  "derive_more",
  "fp-evm",
@@ -6851,7 +6851,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-evm-precompile-balances-erc20"
-version = "2.0.5"
+version = "2.0.6"
 dependencies = [
  "derive_more",
  "fp-evm",
@@ -6944,7 +6944,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-evm-signatures"
-version = "2.0.5"
+version = "2.0.6"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6966,7 +6966,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-farming"
-version = "2.0.5"
+version = "2.0.6"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7082,7 +7082,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-liquid-staking"
-version = "2.0.5"
+version = "2.0.6"
 dependencies = [
  "cumulus-pallet-dmp-queue",
  "cumulus-pallet-parachain-system",
@@ -7130,7 +7130,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-loans"
-version = "2.0.5"
+version = "2.0.6"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7157,7 +7157,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-loans-rpc"
-version = "2.0.5"
+version = "2.0.6"
 dependencies = [
  "jsonrpsee",
  "pallet-loans-rpc-runtime-api",
@@ -7173,7 +7173,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-loans-rpc-runtime-api"
-version = "2.0.5"
+version = "2.0.6"
 dependencies = [
  "parallel-primitives",
  "parity-scale-codec",
@@ -7354,7 +7354,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-prices"
-version = "2.0.5"
+version = "2.0.6"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7445,7 +7445,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-router"
-version = "2.0.5"
+version = "2.0.6"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7466,7 +7466,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-router-rpc"
-version = "2.0.5"
+version = "2.0.6"
 dependencies = [
  "jsonrpsee",
  "pallet-router-rpc-runtime-api",
@@ -7483,7 +7483,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-router-rpc-runtime-api"
-version = "2.0.5"
+version = "2.0.6"
 dependencies = [
  "parallel-primitives",
  "parity-scale-codec",
@@ -7562,7 +7562,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-stableswap"
-version = "2.0.5"
+version = "2.0.6"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7645,7 +7645,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-streaming"
-version = "2.0.5"
+version = "2.0.6"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7720,7 +7720,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-traits"
-version = "2.0.5"
+version = "2.0.6"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7903,7 +7903,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-xcm-helper"
-version = "2.0.5"
+version = "2.0.6"
 dependencies = [
  "cumulus-pallet-dmp-queue",
  "cumulus-pallet-parachain-system",
@@ -7981,7 +7981,7 @@ dependencies = [
 
 [[package]]
 name = "parallel"
-version = "2.0.5"
+version = "2.0.6"
 dependencies = [
  "async-trait",
  "clap",
@@ -8081,7 +8081,7 @@ dependencies = [
 
 [[package]]
 name = "parallel-primitives"
-version = "2.0.5"
+version = "2.0.6"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -8100,7 +8100,7 @@ dependencies = [
 
 [[package]]
 name = "parallel-runtime"
-version = "2.0.5"
+version = "2.0.6"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-dmp-queue",
@@ -8194,7 +8194,7 @@ dependencies = [
 
 [[package]]
 name = "parallel-support"
-version = "2.0.5"
+version = "2.0.6"
 dependencies = [
  "frame-support",
  "log",
@@ -9693,7 +9693,7 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "precompile-utils"
-version = "2.0.5"
+version = "2.0.6"
 dependencies = [
  "evm",
  "fp-evm",
@@ -9717,7 +9717,7 @@ dependencies = [
 
 [[package]]
 name = "precompile-utils-macro"
-version = "2.0.5"
+version = "2.0.6"
 dependencies = [
  "num_enum",
  "proc-macro2",
@@ -10500,7 +10500,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-common"
-version = "2.0.5"
+version = "2.0.6"
 dependencies = [
  "fp-rpc",
  "fp-self-contained",
@@ -10531,7 +10531,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-integration-tests"
-version = "2.0.5"
+version = "2.0.6"
 dependencies = [
  "cumulus-pallet-dmp-queue",
  "cumulus-pallet-parachain-system",
@@ -14283,7 +14283,7 @@ checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "vanilla-runtime"
-version = "2.0.5"
+version = "2.0.6"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-dmp-queue",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
 [workspace.package]
 authors    = ['Parallel Team']
 repository = 'https://github.com/parallel-finance/parallel'
-version    = '2.0.5'
+version    = '2.0.6'
 
 [workspace.dependencies]
 # Substrate dependencies

--- a/pallets/crowdloans/src/types.rs
+++ b/pallets/crowdloans/src/types.rs
@@ -137,6 +137,7 @@ pub enum Releases {
     V0_0_0,
     V1_0_0,
     V2_0_0,
+    V3_0_0,
 }
 
 impl Default for Releases {

--- a/pallets/liquid-staking/src/lib.rs
+++ b/pallets/liquid-staking/src/lib.rs
@@ -576,7 +576,7 @@ pub mod pallet {
             Unlockings::<T>::try_mutate(&unlockings_key, |b| -> DispatchResult {
                 let mut chunks = b.take().unwrap_or_default();
                 let target_era = Self::target_era();
-                if let Some(mut chunk) = chunks.last_mut().filter(|chunk| chunk.era == target_era) {
+                if let Some(chunk) = chunks.last_mut().filter(|chunk| chunk.era == target_era) {
                     chunk.value = chunk.value.saturating_add(amount);
                 } else {
                     chunks.push(UnlockChunk {

--- a/pallets/liquid-staking/src/types.rs
+++ b/pallets/liquid-staking/src/types.rs
@@ -315,7 +315,7 @@ impl<AccountId, Balance: BalanceT + FixedPointOperand> StakingLedger<AccountId, 
     /// Schedule a portion of the stash to be unlocked ready for transfer out after the bond
     /// period ends. If this leaves an amount actively bonded less than
     pub fn unbond(&mut self, value: Balance, target_era: EraIndex) {
-        if let Some(mut chunk) = self
+        if let Some(chunk) = self
             .unlocking
             .last_mut()
             .filter(|chunk| chunk.era == target_era)

--- a/runtime/heiko/src/lib.rs
+++ b/runtime/heiko/src/lib.rs
@@ -180,7 +180,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("heiko"),
     impl_name: create_runtime_str!("heiko"),
     authoring_version: 1,
-    spec_version: 205,
+    spec_version: 206,
     impl_version: 33,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 17,

--- a/runtime/kerria/src/lib.rs
+++ b/runtime/kerria/src/lib.rs
@@ -180,7 +180,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("kerria"),
     impl_name: create_runtime_str!("kerria"),
     authoring_version: 1,
-    spec_version: 205,
+    spec_version: 206,
     impl_version: 33,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 17,

--- a/runtime/parallel/src/lib.rs
+++ b/runtime/parallel/src/lib.rs
@@ -27,6 +27,7 @@ use frame_support::{
         tokens::BalanceConversion,
         AsEnsureOriginWithArg, ChangeMembers, ConstU32, Contains, EitherOfDiverse,
         EqualPrivilegeOnly, Everything, FindAuthor, InstanceFilter, NeverEnsureOrigin, Nothing,
+        OnRuntimeUpgrade,
     },
     weights::{
         constants::{
@@ -184,7 +185,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("parallel"),
     impl_name: create_runtime_str!("parallel"),
     authoring_version: 1,
-    spec_version: 205,
+    spec_version: 206,
     impl_version: 33,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 17,
@@ -2072,7 +2073,7 @@ pub type Executive = frame_executive::Executive<
     frame_system::ChainContext<Runtime>,
     Runtime,
     AllPalletsWithSystem,
-    (),
+    CrowdloansMigrationV3,
 >;
 
 impl fp_self_contained::SelfContainedCall for RuntimeCall {
@@ -2130,6 +2131,23 @@ impl fp_self_contained::SelfContainedCall for RuntimeCall {
             }
             _ => None,
         }
+    }
+}
+
+pub struct CrowdloansMigrationV3;
+impl OnRuntimeUpgrade for CrowdloansMigrationV3 {
+    fn on_runtime_upgrade() -> frame_support::weights::Weight {
+        pallet_crowdloans::migrations::v3::migrate::<Runtime>()
+    }
+
+    #[cfg(feature = "try-runtime")]
+    fn pre_upgrade() -> Result<Vec<u8>, &'static str> {
+        pallet_crowdloans::migrations::v3::pre_migrate::<Runtime>()
+    }
+
+    #[cfg(feature = "try-runtime")]
+    fn post_upgrade(_: Vec<u8>) -> Result<(), &'static str> {
+        pallet_crowdloans::migrations::v3::post_migrate::<Runtime>()
     }
 }
 

--- a/runtime/vanilla/src/lib.rs
+++ b/runtime/vanilla/src/lib.rs
@@ -180,7 +180,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("vanilla"),
     impl_name: create_runtime_str!("vanilla"),
     authoring_version: 1,
-    spec_version: 205,
+    spec_version: 206,
     impl_version: 33,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 17,

--- a/scripts/collator.sh
+++ b/scripts/collator.sh
@@ -20,7 +20,7 @@ VOLUME="chains"
 NODE_KEY="$1"
 KEYSTORE_PATH="$2"
 NODE_NAME="$3"
-DOCKER_IMAGE="parallelfinance/parallel:v2.0.5"
+DOCKER_IMAGE="parallelfinance/parallel:v2.0.6"
 BASE_PATH="/data"
 
 if [ $# -lt 3 ]; then


### PR DESCRIPTION
Add vaults:
- 2040,8-15,5058525762400000,150000000000000000,10881401
- 2013,8-15,1891535952620463,150000000000000000,10881401
- 2030,8-15,222383369000000,150000000000000000,10881401
- 2027,8-15,574831000000000,150000000000000000,10881401
- 2043,8-15,2599910262000000,150000000000000000,10881401
- 2007,8-15,320506980000000,150000000000000000,10881401

Key Changes:
- Storage Migration of Crowdloans.Vaults
- Runtime SpecVersion

Result: Verified with `chopstick` fork environment

before:
<img width="1426" alt="image" src="https://github.com/parallel-finance/parallel/assets/44558375/9dd698a2-18bc-416c-8bba-fcab67c96296">

after:
<img width="1160" alt="image" src="https://github.com/parallel-finance/parallel/assets/44558375/a963a8a2-9726-4d3b-9990-1846a56000dd">
