### PR TITLE
Minor Typo Fixes in Comments and Test Function Names

### DIFF
--- a/pallets/farming/src/lib.rs
+++ b/pallets/farming/src/lib.rs
@@ -104,7 +104,7 @@ pub mod pallet {
     pub enum Error<T> {
         /// Pool does not exist
         PoolDoesNotExist,
-        /// Pool associacted with asset already exists
+        /// Pool associated with asset already exists
         PoolAlreadyExists,
         /// Pool is not active
         PoolIsNotActive,

--- a/pallets/loans/src/tests.rs
+++ b/pallets/loans/src/tests.rs
@@ -1091,7 +1091,7 @@ fn update_market_reward_speed_works() {
 }
 
 #[test]
-fn reward_calculation_one_palyer_in_multi_markets_works() {
+fn reward_calculation_one_player_in_multi_markets_works() {
     new_test_ext().execute_with(|| {
         assert_ok!(Loans::mint(RuntimeOrigin::signed(ALICE), DOT, unit(100)));
         assert_ok!(Loans::mint(RuntimeOrigin::signed(ALICE), KSM, unit(100)));


### PR DESCRIPTION


---


## Description
- Corrected a typo in the comment for the `PoolAlreadyExists` error in the farming pallet.
- Fixed a typo in the test function name in the loans pallet for clarity and consistency.



---